### PR TITLE
Add minimal .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,10 @@
+root = true
+
+[.editorconfig]
+end_of_line = crlf
+
+[*.cs]
+charset = utf-8-bom
+end_of_line = crlf
+indent_style = tab
+indent_size = 4


### PR DESCRIPTION
Noted some whitespace issues in #10, which could be avoided by specifying the indent style in an editorconfig file so here's one; Hopefully this makes it easier for others to contribute without having to care about editor settings, etc.

Also included the end of line handling as CRLF since that seems to be what most\* things are using.

\*) "Most" is based on a statistical method of sampling one `ConfigurableVaultApplicationBase.cs` file with `file`.