### PR TITLE
Fix error message for CreateBackgroundOperation where operation already exists

### DIFF
--- a/MFiles.VAF.Extensions/MultiServerMode/TaskQueueBackgroundOperationManager/CreateBackgroundOperation.cs
+++ b/MFiles.VAF.Extensions/MultiServerMode/TaskQueueBackgroundOperationManager/CreateBackgroundOperation.cs
@@ -81,7 +81,7 @@ namespace MFiles.VAF.Extensions.MultiServerMode
 			{
 				if (this.BackgroundOperations.ContainsKey(name))
 					throw new ArgumentException(
-						$"A background operation with the name {name} in queue {this.QueueId} could not be found.",
+						$"A background operation with the name {name} in queue {this.QueueId} already exists.",
 						nameof(name));
 
 				// Create the background operation.


### PR DESCRIPTION
Originally it said the opposite of what it meant 🤣