### PR TITLE
Fixes Issue 34

### DIFF
--- a/MFiles.VAF.Extensions.Tests/Configuration/ScheduledExecution/ScheduleTests.cs
+++ b/MFiles.VAF.Extensions.Tests/Configuration/ScheduledExecution/ScheduleTests.cs
@@ -137,5 +137,47 @@ namespace MFiles.VAF.Extensions.Tests.ScheduledExecution
 				new DateTime(2021, 03, 18, 17, 00, 00)
 			};
 		}
+
+		[TestMethod]
+		public void DailyTriggerToDashboardDisplayString_RunOnStartup_False()
+		{
+			var schedule = new Schedule()
+			{
+				Triggers = new List<Trigger>()
+				{
+					new DailyTrigger()
+					{
+							TriggerTimes = new List<TimeSpan>(){ new TimeSpan(1, 30, 32) }
+					}
+				},
+				RunOnVaultStartup = false
+			};
+			Assert.AreEqual
+			(
+				"<p>Runs according to the following schedule:<ul><li>Daily at the following times: 01:30:32.</li></ul></p>",
+				schedule.ToDashboardDisplayString()
+			);
+		}
+
+		[TestMethod]
+		public void DailyTriggerToDashboardDisplayString_RunOnStartup_True()
+		{
+			var schedule = new Schedule()
+			{
+				Triggers = new List<Trigger>()
+				{
+					new DailyTrigger()
+					{
+							TriggerTimes = new List<TimeSpan>(){ new TimeSpan(1, 30, 32) }
+					}
+				},
+				RunOnVaultStartup = true
+			};
+			Assert.AreEqual
+			(
+				"<p>Runs when the vault starts and according to the following schedule:<ul><li>Daily at the following times: 01:30:32.</li></ul></p>",
+				schedule.ToDashboardDisplayString()
+			);
+		}
 	}
 }

--- a/MFiles.VAF.Extensions.Tests/Configuration/TimeSpanExTests.cs
+++ b/MFiles.VAF.Extensions.Tests/Configuration/TimeSpanExTests.cs
@@ -39,7 +39,8 @@ namespace MFiles.VAF.Extensions.Tests.Configuration
 		{
 			var output = JsonConvert.DeserializeObject<Wrapper>(@"{ ""TimeSpanEx"" : { ""Interval"" : ""01:02:03"", ""RunOnVaultStartup"" : true } }");
 			Assert.IsNotNull(output?.TimeSpanEx);
-			Assert.IsTrue(output.TimeSpanEx.RunOnVaultStartup);
+			Assert.IsTrue(output.TimeSpanEx.RunOnVaultStartup.HasValue);
+			Assert.IsTrue(output.TimeSpanEx.RunOnVaultStartup.Value);
 		}
 
 		[TestMethod]
@@ -47,13 +48,29 @@ namespace MFiles.VAF.Extensions.Tests.Configuration
 		{
 			var output = JsonConvert.DeserializeObject<Wrapper>(@"{ ""TimeSpanEx"" : { ""Interval"" : ""01:02:03"", ""RunOnVaultStartup"" : false } }");
 			Assert.IsNotNull(output?.TimeSpanEx);
-			Assert.IsFalse(output.TimeSpanEx.RunOnVaultStartup);
+			Assert.IsTrue(output.TimeSpanEx.RunOnVaultStartup.HasValue);
+			Assert.IsFalse(output.TimeSpanEx.RunOnVaultStartup.Value);
 		}
 
 		[TestMethod]
 		public void SerializesCorrectly()
 		{
 			var input = new TimeSpanEx() { Interval = new TimeSpan(1, 2, 3) };
+			// Note: we force RunOnVaultStartup to true for TimeSpanEx/TimeSpan, for legacy compatibility.
+			Assert.AreEqual(@"{""Interval"":""01:02:03"",""RunOnVaultStartup"":true}", JsonConvert.SerializeObject(input));
+		}
+
+		[TestMethod]
+		public void SerializesCorrectlyWithRunOnVaultStartup_Null()
+		{
+			var input = new TimeSpanEx() { Interval = new TimeSpan(1, 2, 3), RunOnVaultStartup = null };
+			Assert.AreEqual(@"{""Interval"":""01:02:03""}", JsonConvert.SerializeObject(input));
+		}
+
+		[TestMethod]
+		public void SerializesCorrectlyWithRunOnVaultStartup_True()
+		{
+			var input = new TimeSpanEx() { Interval = new TimeSpan(1, 2, 3), RunOnVaultStartup = true };
 			Assert.AreEqual(@"{""Interval"":""01:02:03"",""RunOnVaultStartup"":true}", JsonConvert.SerializeObject(input));
 		}
 

--- a/MFiles.VAF.Extensions.Tests/Configuration/TimeSpanExTests.cs
+++ b/MFiles.VAF.Extensions.Tests/Configuration/TimeSpanExTests.cs
@@ -1,0 +1,67 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.Serialization;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace MFiles.VAF.Extensions.Tests.Configuration
+{
+	[DataContract]
+	internal class Wrapper
+	{
+		[DataMember]
+		public TimeSpanEx TimeSpanEx { get; set; }
+	}
+	[TestClass]
+	public class TimeSpanExTests
+	{
+		[TestMethod]
+		public void DeserializesTimeSpanString()
+		{
+			var output = JsonConvert.DeserializeObject<Wrapper>(@"{ ""TimeSpanEx"" : ""11:01:02"" }");
+			Assert.IsNotNull(output?.TimeSpanEx);
+			Assert.AreEqual(new TimeSpan(11, 01, 02), output.TimeSpanEx.Interval);
+		}
+
+		[TestMethod]
+		public void DeserializesTimeSpanExString()
+		{
+			var output = JsonConvert.DeserializeObject<Wrapper>(@"{ ""TimeSpanEx"" : { ""Interval"" : ""01:02:03"" } }");
+			Assert.IsNotNull(output?.TimeSpanEx);
+			Assert.AreEqual(new TimeSpan(01, 02, 03), output.TimeSpanEx.Interval);
+		}
+
+		[TestMethod]
+		public void DeserializesTimeSpanExWithRunOnVaultStartup_True()
+		{
+			var output = JsonConvert.DeserializeObject<Wrapper>(@"{ ""TimeSpanEx"" : { ""Interval"" : ""01:02:03"", ""RunOnVaultStartup"" : true } }");
+			Assert.IsNotNull(output?.TimeSpanEx);
+			Assert.IsTrue(output.TimeSpanEx.RunOnVaultStartup);
+		}
+
+		[TestMethod]
+		public void DeserializesTimeSpanExWithRunOnVaultStartup_False()
+		{
+			var output = JsonConvert.DeserializeObject<Wrapper>(@"{ ""TimeSpanEx"" : { ""Interval"" : ""01:02:03"", ""RunOnVaultStartup"" : false } }");
+			Assert.IsNotNull(output?.TimeSpanEx);
+			Assert.IsFalse(output.TimeSpanEx.RunOnVaultStartup);
+		}
+
+		[TestMethod]
+		public void SerializesCorrectly()
+		{
+			var input = new TimeSpanEx() { Interval = new TimeSpan(1, 2, 3) };
+			Assert.AreEqual(@"{""Interval"":""01:02:03"",""RunOnVaultStartup"":true}", JsonConvert.SerializeObject(input));
+		}
+
+		[TestMethod]
+		public void SerializesCorrectlyWithRunOnVaultStartup_False()
+		{
+			var input = new TimeSpanEx() { Interval = new TimeSpan(1, 2, 3), RunOnVaultStartup = false };
+			Assert.AreEqual(@"{""Interval"":""01:02:03"",""RunOnVaultStartup"":false}", JsonConvert.SerializeObject(input));
+		}
+	}
+}

--- a/MFiles.VAF.Extensions.Tests/ExtensionMethods/FormattingExtensionMethods.cs
+++ b/MFiles.VAF.Extensions.Tests/ExtensionMethods/FormattingExtensionMethods.cs
@@ -16,7 +16,37 @@ namespace MFiles.VAF.Extensions.Tests.ExtensionMethods
 			var interval = new TimeSpan(1, 30, 32);
 			Assert.AreEqual
 			(
-				"<p>Runs every 1 hour, 30 minutes, and 32 seconds.<br /></p>", 
+				"<p>Runs every 1 hour, 30 minutes, and 32 seconds.<br /></p>",
+				interval.ToDashboardDisplayString()
+			);
+		}
+
+		[TestMethod]
+		public void ToDashboardDisplayString_RunOnStartup_False()
+		{
+			var interval = new TimeSpanEx()
+			{
+				Interval = new TimeSpan(1, 30, 32),
+				RunOnVaultStartup = false
+			};
+			Assert.AreEqual
+			(
+				"<p>Runs every 1 hour, 30 minutes, and 32 seconds.<br /></p>",
+				interval.ToDashboardDisplayString()
+			);
+		}
+
+		[TestMethod]
+		public void ToDashboardDisplayString_RunOnStartup_True()
+		{
+			var interval = new TimeSpanEx()
+			{
+				Interval = new TimeSpan(1, 30, 32),
+				RunOnVaultStartup = true
+			};
+			Assert.AreEqual
+			(
+				"<p>Runs on vault startup and every 1 hour, 30 minutes, and 32 seconds.<br /></p>",
 				interval.ToDashboardDisplayString()
 			);
 		}

--- a/MFiles.VAF.Extensions.Tests/ExtensionMethods/FormattingExtensionMethods.cs
+++ b/MFiles.VAF.Extensions.Tests/ExtensionMethods/FormattingExtensionMethods.cs
@@ -16,7 +16,7 @@ namespace MFiles.VAF.Extensions.Tests.ExtensionMethods
 			var interval = new TimeSpan(1, 30, 32);
 			Assert.AreEqual
 			(
-				"<p>Runs every 1 hour, 30 minutes, and 32 seconds.<br /></p>",
+				"<p>Runs on vault startup and every 1 hour, 30 minutes, and 32 seconds.<br /></p>",
 				interval.ToDashboardDisplayString()
 			);
 		}

--- a/MFiles.VAF.Extensions/ConfigurableVaultApplicationBase.ConfigurationUpdated.cs
+++ b/MFiles.VAF.Extensions/ConfigurableVaultApplicationBase.ConfigurationUpdated.cs
@@ -18,7 +18,7 @@ namespace MFiles.VAF.Extensions
 			base.OnConfigurationUpdated(oldConfiguration, updateExternals);
 
 			// Populate the task processing schedule configuration.
-			this.RecurringOperationConfigurationManager?.PopulateFromConfiguration();
+			this.RecurringOperationConfigurationManager?.PopulateFromConfiguration(isVaultStartup: false);
 		}
 
 		/// <inheritdoc />
@@ -28,7 +28,7 @@ namespace MFiles.VAF.Extensions
 			base.StartOperations(vaultPersistent);
 
 			// Ensure that our recurring configuration is updated.
-			this.RecurringOperationConfigurationManager?.PopulateFromConfiguration();
+			this.RecurringOperationConfigurationManager?.PopulateFromConfiguration(isVaultStartup: true);
 		}
 	}
 }

--- a/MFiles.VAF.Extensions/Configuration/Frequency.cs
+++ b/MFiles.VAF.Extensions/Configuration/Frequency.cs
@@ -6,31 +6,6 @@ using System.Runtime.Serialization;
 namespace MFiles.VAF.Extensions
 {
 	[DataContract]
-	public class TimeSpanEx
-	{
-		[DataMember]
-		[JsonConfEditor(TypeEditor = "time")]
-		public TimeSpan Interval { get; set; }
-
-		[DataMember]
-		[JsonConfEditor
-		(
-			Label = "Run on vault start",
-			HelpText = "If true, runs when the vault starts.  If false, the first run is scheduled to be after the interval has elapsed."
-		)]
-		public bool RunOnVaultStartup { get; set; }
-
-		public static implicit operator TimeSpan(TimeSpanEx input)
-		{
-			return input?.Interval ?? TimeSpan.Zero;
-		}
-
-		public static implicit operator TimeSpanEx(TimeSpan input)
-		{
-			return new TimeSpanEx() { Interval = input };
-		}
-	}
-	[DataContract]
 	public class Frequency
 		: IRecurrenceConfiguration
 	{

--- a/MFiles.VAF.Extensions/Configuration/Frequency.cs
+++ b/MFiles.VAF.Extensions/Configuration/Frequency.cs
@@ -37,7 +37,7 @@ namespace MFiles.VAF.Extensions
 		public Schedule Schedule { get; set; }
 
 		/// <inheritdoc />
-		public bool RunOnVaultStartup
+		public bool? RunOnVaultStartup
 		{
 			get
 			{

--- a/MFiles.VAF.Extensions/Configuration/IRecurrenceConfiguration.cs
+++ b/MFiles.VAF.Extensions/Configuration/IRecurrenceConfiguration.cs
@@ -21,6 +21,6 @@ namespace MFiles.VAF.Extensions
 		/// <summary>
 		/// Whether the processor should run on vault startup (in addition to any other schedule or interval).
 		/// </summary>
-		bool RunOnVaultStartup { get; }
+		bool? RunOnVaultStartup { get; }
 	}
 }

--- a/MFiles.VAF.Extensions/Configuration/IRecurrenceConfiguration.cs
+++ b/MFiles.VAF.Extensions/Configuration/IRecurrenceConfiguration.cs
@@ -17,5 +17,10 @@ namespace MFiles.VAF.Extensions
 		/// <param name="after">The current execution time, or null to use the current time.</param>
 		/// <returns>The next-run time.  May be null if there are no valid next-run times.</returns>
 		DateTime? GetNextExecution(DateTime? after = null);
+
+		/// <summary>
+		/// Whether the processor should run on vault startup (in addition to any other schedule or interval).
+		/// </summary>
+		bool RunOnVaultStartup { get; }
 	}
 }

--- a/MFiles.VAF.Extensions/Configuration/ScheduledExecution/Schedule.cs
+++ b/MFiles.VAF.Extensions/Configuration/ScheduledExecution/Schedule.cs
@@ -30,7 +30,8 @@ namespace MFiles.VAF.Extensions.ScheduledExecution
 		[JsonConfEditor
 		(
 			Label = "Run on vault start",
-			HelpText = "If true, runs when the vault starts.  If false, the first run is calculated from the triggers."
+			HelpText = "If true, runs when the vault starts.  If false, the first run is calculated from the triggers.",
+			DefaultValue = false
 		)]
 		public bool RunOnVaultStartup { get; set; }
 

--- a/MFiles.VAF.Extensions/Configuration/ScheduledExecution/Schedule.cs
+++ b/MFiles.VAF.Extensions/Configuration/ScheduledExecution/Schedule.cs
@@ -33,7 +33,7 @@ namespace MFiles.VAF.Extensions.ScheduledExecution
 			HelpText = "If true, runs when the vault starts.  If false, the first run is calculated from the triggers.",
 			DefaultValue = false
 		)]
-		public bool RunOnVaultStartup { get; set; }
+		public bool? RunOnVaultStartup { get; set; }
 
 		/// <summary>
 		/// Gets the next execution datetime for this trigger.
@@ -59,11 +59,11 @@ namespace MFiles.VAF.Extensions.ScheduledExecution
 		public string ToDashboardDisplayString()
 		{
 			if (this.Triggers == null || this.Triggers.Count == 0)
-				return this.RunOnVaultStartup
+				return this.RunOnVaultStartup.HasValue && this.RunOnVaultStartup.Value
 					? "<p>Runs when the vault starts, but does not repeat.<br /></p>"
 					: "<p>No schedule specified; does not repeat.<br /></p>";
 
-			var output = this.RunOnVaultStartup
+			var output = this.RunOnVaultStartup.HasValue && this.RunOnVaultStartup.Value
 				? "<p>Runs when the vault starts and according to the following schedule:"
 				: "<p>Runs according to the following schedule:";
 

--- a/MFiles.VAF.Extensions/Configuration/ScheduledExecution/Schedule.cs
+++ b/MFiles.VAF.Extensions/Configuration/ScheduledExecution/Schedule.cs
@@ -26,6 +26,14 @@ namespace MFiles.VAF.Extensions.ScheduledExecution
 		[DataMember]
 		public List<Trigger> Triggers { get; set; } = new List<Trigger>();
 
+		[DataMember]
+		[JsonConfEditor
+		(
+			Label = "Run on vault start",
+			HelpText = "If true, runs when the vault starts.  If false, the first run is calculated from the triggers."
+		)]
+		public bool RunOnVaultStartup { get; set; }
+
 		/// <summary>
 		/// Gets the next execution datetime for this trigger.
 		/// </summary>
@@ -50,9 +58,13 @@ namespace MFiles.VAF.Extensions.ScheduledExecution
 		public string ToDashboardDisplayString()
 		{
 			if (this.Triggers == null || this.Triggers.Count == 0)
-				return "<p>No schedule specified; does not repeat.<br /></p>";
+				return this.RunOnVaultStartup
+					? "<p>Runs when the vault starts, but does not repeat.<br /></p>"
+					: "<p>No schedule specified; does not repeat.<br /></p>";
 
-			var output = "<p>Runs according to the following schedule:";
+			var output = this.RunOnVaultStartup
+				? "<p>Runs when the vault starts and according to the following schedule:"
+				: "<p>Runs according to the following schedule:";
 
 			// Output the triggers as a HTML list.
 			output += "<ul>";

--- a/MFiles.VAF.Extensions/Configuration/TimeSpanEx.cs
+++ b/MFiles.VAF.Extensions/Configuration/TimeSpanEx.cs
@@ -8,6 +8,90 @@ using System.Runtime.Serialization;
 
 namespace MFiles.VAF.Extensions
 {
+	[DataContract]
+	[JsonConverter(typeof(TimeSpanExJsonConverter))]
+	public class TimeSpanEx
+		: IRecurrenceConfiguration
+	{
+		[DataMember]
+		[JsonConfEditor(TypeEditor = "time")]
+		public TimeSpan Interval { get; set; }
+
+		[DataMember]
+		[JsonConfEditor
+		(
+			Label = "Run on vault start",
+			HelpText = "If true, runs when the vault starts.  If false, the first run is scheduled to be after the interval has elapsed.",
+			DefaultValue = true
+		)]
+		public bool RunOnVaultStartup { get; set; } = true;
+
+		public DateTime? GetNextExecution(DateTime? after = null)
+		{
+			return (after?.ToUniversalTime() ?? DateTime.UtcNow).Add(this.Interval);
+		}
+
+		public string ToDashboardDisplayString()
+		{
+			// Sanity.
+			if (null == this?.Interval || this.Interval <= TimeSpan.Zero)
+				return "<p>No timespan specified; does not repeat.<br /></p>";
+
+			var prefix = "<p>Runs";
+			if (this.RunOnVaultStartup)
+				prefix += " on vault startup and";
+			var suffix = ".<br /></p>";
+
+			// Seconds be easy.
+			if (this.Interval <= TimeSpan.FromSeconds(120))
+				return $"{prefix} every {(int)this.Interval.TotalSeconds} seconds{suffix}";
+
+			// Build a text representation
+			var components = new List<string>();
+			if (this.Interval.Days > 0)
+				components.Add($"{this.Interval.Days} day{(this.Interval.Days != 1 ? "s" : "")}");
+			if (this.Interval.Hours > 0)
+				components.Add($"{this.Interval.Hours} hour{(this.Interval.Hours != 1 ? "s" : "")}");
+			if (this.Interval.Minutes > 0)
+				components.Add($"{this.Interval.Minutes} minute{(this.Interval.Minutes != 1 ? "s" : "")}");
+			if (this.Interval.Seconds > 0)
+				components.Add($"{this.Interval.Seconds} second{(this.Interval.Seconds != 1 ? "s" : "")}");
+
+			// Build a text representation
+			var output = prefix + " every ";
+			for (var i = 0; i < components.Count; i++)
+			{
+				if (i == 0)
+				{
+					output += components[i];
+				}
+				else if (i == components.Count - 1)
+				{
+					output += ", and " + components[i];
+				}
+				else
+				{
+					output += ", " + components[i];
+				}
+			}
+			return output + suffix;
+		}
+
+		public static implicit operator TimeSpan(TimeSpanEx input)
+		{
+			return input?.Interval ?? TimeSpan.Zero;
+		}
+
+		public static implicit operator TimeSpanEx(TimeSpan input)
+		{
+			return new TimeSpanEx() { Interval = input };
+		}
+	}
+
+	/// <summary>
+	/// Controls serialisation/deserialisation of <see cref="TimeSpanEx"/>.
+	/// This allows the system to additionally deserialize <see cref="TimeSpan"/> data to <see cref="TimeSpanEx"/>.
+	/// </summary>
 	internal class TimeSpanExJsonConverter
 		: JsonConverter
 	{
@@ -101,86 +185,6 @@ namespace MFiles.VAF.Extensions
 			// End the object.
 			writer.WriteEndObject();
 
-		}
-	}
-
-	[DataContract]
-	[JsonConverter(typeof(TimeSpanExJsonConverter))]
-	public class TimeSpanEx
-		: IRecurrenceConfiguration
-	{
-		[DataMember]
-		[JsonConfEditor(TypeEditor = "time")]
-		public TimeSpan Interval { get; set; }
-
-		[DataMember]
-		[JsonConfEditor
-		(
-			Label = "Run on vault start",
-			HelpText = "If true, runs when the vault starts.  If false, the first run is scheduled to be after the interval has elapsed.",
-			DefaultValue = true
-		)]
-		public bool RunOnVaultStartup { get; set; } = true;
-
-		public DateTime? GetNextExecution(DateTime? after = null)
-		{
-			return (after?.ToUniversalTime() ?? DateTime.UtcNow).Add(this.Interval);
-		}
-
-		public string ToDashboardDisplayString()
-		{
-			// Sanity.
-			if (null == this?.Interval || this.Interval <= TimeSpan.Zero)
-				return "<p>No timespan specified; does not repeat.<br /></p>";
-
-			var prefix = "<p>Runs";
-			if (this.RunOnVaultStartup)
-				prefix += " on vault startup and";
-			var suffix = ".<br /></p>";
-
-			// Seconds be easy.
-			if (this.Interval <= TimeSpan.FromSeconds(120))
-				return $"{prefix} every {(int)this.Interval.TotalSeconds} seconds{suffix}";
-
-			// Build a text representation
-			var components = new List<string>();
-			if (this.Interval.Days > 0)
-				components.Add($"{this.Interval.Days} day{(this.Interval.Days != 1 ? "s" : "")}");
-			if (this.Interval.Hours > 0)
-				components.Add($"{this.Interval.Hours} hour{(this.Interval.Hours != 1 ? "s" : "")}");
-			if (this.Interval.Minutes > 0)
-				components.Add($"{this.Interval.Minutes} minute{(this.Interval.Minutes != 1 ? "s" : "")}");
-			if (this.Interval.Seconds > 0)
-				components.Add($"{this.Interval.Seconds} second{(this.Interval.Seconds != 1 ? "s" : "")}");
-
-			// Build a text representation
-			var output = prefix + " every ";
-			for (var i = 0; i < components.Count; i++)
-			{
-				if (i == 0)
-				{
-					output += components[i];
-				}
-				else if (i == components.Count - 1)
-				{
-					output += ", and " + components[i];
-				}
-				else
-				{
-					output += ", " + components[i];
-				}
-			}
-			return output + suffix;
-		}
-
-		public static implicit operator TimeSpan(TimeSpanEx input)
-		{
-			return input?.Interval ?? TimeSpan.Zero;
-		}
-
-		public static implicit operator TimeSpanEx(TimeSpan input)
-		{
-			return new TimeSpanEx() { Interval = input };
 		}
 	}
 }

--- a/MFiles.VAF.Extensions/Configuration/TimeSpanEx.cs
+++ b/MFiles.VAF.Extensions/Configuration/TimeSpanEx.cs
@@ -24,7 +24,7 @@ namespace MFiles.VAF.Extensions
 			HelpText = "If true, runs when the vault starts.  If false, the first run is scheduled to be after the interval has elapsed.",
 			DefaultValue = true
 		)]
-		public bool RunOnVaultStartup { get; set; } = true;
+		public bool? RunOnVaultStartup { get; set; } = true;
 
 		public DateTime? GetNextExecution(DateTime? after = null)
 		{
@@ -38,7 +38,7 @@ namespace MFiles.VAF.Extensions
 				return "<p>No timespan specified; does not repeat.<br /></p>";
 
 			var prefix = "<p>Runs";
-			if (this.RunOnVaultStartup)
+			if (this.RunOnVaultStartup.HasValue && this.RunOnVaultStartup.Value)
 				prefix += " on vault startup and";
 			var suffix = ".<br /></p>";
 

--- a/MFiles.VAF.Extensions/Configuration/TimeSpanEx.cs
+++ b/MFiles.VAF.Extensions/Configuration/TimeSpanEx.cs
@@ -1,0 +1,86 @@
+﻿using MFiles.VAF.Configuration;
+using System;
+using System.Collections.Generic;
+using System.Runtime.Serialization;
+
+namespace MFiles.VAF.Extensions
+{
+	[DataContract]
+	public class TimeSpanEx
+		: IRecurrenceConfiguration
+	{
+		[DataMember]
+		[JsonConfEditor(TypeEditor = "time")]
+		public TimeSpan Interval { get; set; }
+
+		[DataMember]
+		[JsonConfEditor
+		(
+			Label = "Run on vault start",
+			HelpText = "If true, runs when the vault starts.  If false, the first run is scheduled to be after the interval has elapsed.",
+			DefaultValue = true
+		)]
+		public bool RunOnVaultStartup { get; set; } = true;
+
+		public DateTime? GetNextExecution(DateTime? after = null)
+		{
+			return (after?.ToUniversalTime() ?? DateTime.UtcNow).Add(this.Interval);
+		}
+
+		public string ToDashboardDisplayString()
+		{
+			// Sanity.
+			if (null == this?.Interval || this.Interval <= TimeSpan.Zero)
+				return "<p>No timespan specified; does not repeat.<br /></p>";
+
+			var prefix = "<p>Runs";
+			if (this.RunOnVaultStartup)
+				prefix += " on vault startup and";
+			var suffix = ".<br /></p>";
+
+			// Seconds be easy.
+			if (this.Interval <= TimeSpan.FromSeconds(120))
+				return $"{prefix} every {(int)this.Interval.TotalSeconds} seconds{suffix}";
+
+			// Build a text representation
+			var components = new List<string>();
+			if (this.Interval.Days > 0)
+				components.Add($"{this.Interval.Days} day{(this.Interval.Days != 1 ? "s" : "")}");
+			if (this.Interval.Hours > 0)
+				components.Add($"{this.Interval.Hours} hour{(this.Interval.Hours != 1 ? "s" : "")}");
+			if (this.Interval.Minutes > 0)
+				components.Add($"{this.Interval.Minutes} minute{(this.Interval.Minutes != 1 ? "s" : "")}");
+			if (this.Interval.Seconds > 0)
+				components.Add($"{this.Interval.Seconds} second{(this.Interval.Seconds != 1 ? "s" : "")}");
+
+			// Build a text representation
+			var output = prefix + " every ";
+			for (var i = 0; i < components.Count; i++)
+			{
+				if (i == 0)
+				{
+					output += components[i];
+				}
+				else if (i == components.Count - 1)
+				{
+					output += ", and " + components[i];
+				}
+				else
+				{
+					output += ", " + components[i];
+				}
+			}
+			return output + suffix;
+		}
+
+		public static implicit operator TimeSpan(TimeSpanEx input)
+		{
+			return input?.Interval ?? TimeSpan.Zero;
+		}
+
+		public static implicit operator TimeSpanEx(TimeSpan input)
+		{
+			return new TimeSpanEx() { Interval = input };
+		}
+	}
+}

--- a/MFiles.VAF.Extensions/ExtensionMethods/FormattingExtensionMethods.cs
+++ b/MFiles.VAF.Extensions/ExtensionMethods/FormattingExtensionMethods.cs
@@ -89,39 +89,34 @@ namespace MFiles.VAF.Extensions
 		/// </summary>
 		/// <param name="timespan">The timespan to convert.</param>
 		/// <returns>A string in English describing the timespan.</returns>
-		public static string ToDashboardDisplayString(this TimeSpan timespan)
-		{
-			return ((TimeSpan?)timespan).ToDashboardDisplayString();
-		}
-
-		/// <summary>
-		/// Converts <paramref name="timespan"/> to a string for display on a dashboard.
-		/// </summary>
-		/// <param name="timespan">The timespan to convert.</param>
-		/// <returns>A string in English describing the timespan.</returns>
-		public static string ToDashboardDisplayString(this TimeSpan? timespan)
+		public static string ToDashboardDisplayString(this TimeSpanEx timespan)
 		{
 			// Sanity.
-			if (false == timespan.HasValue || timespan.Value <= TimeSpan.Zero)
+			if (null == timespan?.Interval || timespan.Interval <= TimeSpan.Zero)
 				return "<p>No timespan specified; does not repeat.<br /></p>";
 
+			var prefix = "<p>Runs";
+			if (timespan.RunOnVaultStartup)
+				prefix += " on vault startup and";
+			var suffix = ".<br /></p>";
+
 			// Seconds be easy.
-			if (timespan.Value <= TimeSpan.FromSeconds(120))
-				return $"<p>Runs every {(int)timespan.Value.TotalSeconds} seconds.<br /></p>";
+			if (timespan.Interval <= TimeSpan.FromSeconds(120))
+				return $"{prefix} every {(int)timespan.Interval.TotalSeconds} seconds{suffix}";
 
 			// Build a text representation
 			var components = new List<string>();
-			if (timespan.Value.Days > 0)
-				components.Add($"{timespan.Value.Days} day{(timespan.Value.Days != 1 ? "s" : "")}");
-			if (timespan.Value.Hours > 0)
-				components.Add($"{timespan.Value.Hours} hour{(timespan.Value.Hours != 1 ? "s" : "")}");
-			if (timespan.Value.Minutes > 0)
-				components.Add($"{timespan.Value.Minutes} minute{(timespan.Value.Minutes != 1 ? "s" : "")}");
-			if (timespan.Value.Seconds > 0)
-				components.Add($"{timespan.Value.Seconds} second{(timespan.Value.Seconds != 1 ? "s" : "")}");
+			if (timespan.Interval.Days > 0)
+				components.Add($"{timespan.Interval.Days} day{(timespan.Interval.Days != 1 ? "s" : "")}");
+			if (timespan.Interval.Hours > 0)
+				components.Add($"{timespan.Interval.Hours} hour{(timespan.Interval.Hours != 1 ? "s" : "")}");
+			if (timespan.Interval.Minutes > 0)
+				components.Add($"{timespan.Interval.Minutes} minute{(timespan.Interval.Minutes != 1 ? "s" : "")}");
+			if (timespan.Interval.Seconds > 0)
+				components.Add($"{timespan.Interval.Seconds} second{(timespan.Interval.Seconds != 1 ? "s" : "")}");
 
 			// Build a text representation
-			var output = "<p>Runs every ";
+			var output = prefix + " every ";
 			for (var i = 0; i < components.Count; i++)
 			{
 				if (i == 0)
@@ -137,7 +132,31 @@ namespace MFiles.VAF.Extensions
 					output += ", " + components[i];
 				}
 			}
-			return output + ".<br /></p>";
+			return output + suffix;
+		}
+
+		/// <summary>
+		/// Converts <paramref name="timespan"/> to a string for display on a dashboard.
+		/// </summary>
+		/// <param name="timespan">The timespan to convert.</param>
+		/// <returns>A string in English describing the timespan.</returns>
+		public static string ToDashboardDisplayString(this TimeSpan timespan)
+		{
+			return ((TimeSpanEx)timespan).ToDashboardDisplayString();
+		}
+
+		/// <summary>
+		/// Converts <paramref name="timespan"/> to a string for display on a dashboard.
+		/// </summary>
+		/// <param name="timespan">The timespan to convert.</param>
+		/// <returns>A string in English describing the timespan.</returns>
+		public static string ToDashboardDisplayString(this TimeSpan? timespan)
+		{
+			// Sanity.
+			if (false == timespan.HasValue || timespan.Value <= TimeSpan.Zero)
+				return "<p>No timespan specified; does not repeat.<br /></p>";
+
+			return ((TimeSpanEx)timespan.Value).ToDashboardDisplayString();
 		}
 
 

--- a/MFiles.VAF.Extensions/ExtensionMethods/FormattingExtensionMethods.cs
+++ b/MFiles.VAF.Extensions/ExtensionMethods/FormattingExtensionMethods.cs
@@ -89,57 +89,6 @@ namespace MFiles.VAF.Extensions
 		/// </summary>
 		/// <param name="timespan">The timespan to convert.</param>
 		/// <returns>A string in English describing the timespan.</returns>
-		public static string ToDashboardDisplayString(this TimeSpanEx timespan)
-		{
-			// Sanity.
-			if (null == timespan?.Interval || timespan.Interval <= TimeSpan.Zero)
-				return "<p>No timespan specified; does not repeat.<br /></p>";
-
-			var prefix = "<p>Runs";
-			if (timespan.RunOnVaultStartup)
-				prefix += " on vault startup and";
-			var suffix = ".<br /></p>";
-
-			// Seconds be easy.
-			if (timespan.Interval <= TimeSpan.FromSeconds(120))
-				return $"{prefix} every {(int)timespan.Interval.TotalSeconds} seconds{suffix}";
-
-			// Build a text representation
-			var components = new List<string>();
-			if (timespan.Interval.Days > 0)
-				components.Add($"{timespan.Interval.Days} day{(timespan.Interval.Days != 1 ? "s" : "")}");
-			if (timespan.Interval.Hours > 0)
-				components.Add($"{timespan.Interval.Hours} hour{(timespan.Interval.Hours != 1 ? "s" : "")}");
-			if (timespan.Interval.Minutes > 0)
-				components.Add($"{timespan.Interval.Minutes} minute{(timespan.Interval.Minutes != 1 ? "s" : "")}");
-			if (timespan.Interval.Seconds > 0)
-				components.Add($"{timespan.Interval.Seconds} second{(timespan.Interval.Seconds != 1 ? "s" : "")}");
-
-			// Build a text representation
-			var output = prefix + " every ";
-			for (var i = 0; i < components.Count; i++)
-			{
-				if (i == 0)
-				{
-					output += components[i];
-				}
-				else if (i == components.Count - 1)
-				{
-					output += ", and " + components[i];
-				}
-				else
-				{
-					output += ", " + components[i];
-				}
-			}
-			return output + suffix;
-		}
-
-		/// <summary>
-		/// Converts <paramref name="timespan"/> to a string for display on a dashboard.
-		/// </summary>
-		/// <param name="timespan">The timespan to convert.</param>
-		/// <returns>A string in English describing the timespan.</returns>
 		public static string ToDashboardDisplayString(this TimeSpan timespan)
 		{
 			return ((TimeSpanEx)timespan).ToDashboardDisplayString();

--- a/MFiles.VAF.Extensions/Readme.md
+++ b/MFiles.VAF.Extensions/Readme.md
@@ -187,7 +187,7 @@ namespace sampleApplication
 
 ###### Suppressing an interval-based task from running at vault startup
 
-Declaring the property or field type as `TimeSpanEx` will allow the user to confirm whether the task should or should not run when the vault starts.
+Declaring the property or field type as `TimeSpanEx` will allow the user to confirm whether the task should or should not run when the vault starts.  By default this value is true (run at vault startup, then after a time period).
 
 ```csharp
 namespace sampleApplication
@@ -217,7 +217,12 @@ namespace sampleApplication
 			VaultApplication.QueueId,
 			VaultApplication.ImportDataFromRemoteSystemTaskType
 		)]
-		public TimeSpanEx Interval { get; set; } = new TimeSpan(0, 10, 0);
+		public TimeSpanEx Interval { get; set; } = new TimeSpanEx()
+		{
+			Interval = new TimeSpan(0, 10, 0),
+			// This one does not run at startup, although the user can change this in the admin configuration.
+			RunOnVaultStartup = false
+		};
 	}
 }
 ```

--- a/MFiles.VAF.Extensions/RecurringOperationConfigurationManager.cs
+++ b/MFiles.VAF.Extensions/RecurringOperationConfigurationManager.cs
@@ -306,7 +306,7 @@ namespace MFiles.VAF.Extensions
 						if (null == value)
 							continue;
 						if (value.GetType() == typeof(TimeSpan))
-							value = new WrappedTimeSpan((TimeSpan)value);
+							value = (TimeSpanEx)value;
 
 						// Validate that the value is a recurring operation.
 						if (!typeof(IRecurrenceConfiguration).IsAssignableFrom(value.GetType()))
@@ -373,7 +373,7 @@ namespace MFiles.VAF.Extensions
 						if (null == value)
 							continue;
 						if (value.GetType() == typeof(TimeSpan))
-							value = new WrappedTimeSpan((TimeSpan)value);
+							value = (TimeSpanEx)value;
 
 						// Validate the type.
 						if (!typeof(IRecurrenceConfiguration).IsAssignableFrom(value.GetType()))
@@ -405,33 +405,6 @@ namespace MFiles.VAF.Extensions
 					this.GetTaskProcessorConfiguration(input, p, out a);
 					schedules.AddRange(a);
 				}
-			}
-		}
-		internal class WrappedTimeSpan
-			: IRecurrenceConfiguration
-		{
-			public TimeSpan TimeSpan { get; set; }
-
-			/// <inheritdoc/>
-			public bool? RunOnVaultStartup => true;
-
-			public WrappedTimeSpan(TimeSpan timeSpan)
-			{
-				this.TimeSpan = timeSpan;
-			}
-			public static implicit operator TimeSpan(WrappedTimeSpan input)
-				=> input?.TimeSpan ?? TimeSpan.Zero;
-			public static implicit operator WrappedTimeSpan(TimeSpan input)
-				=> new WrappedTimeSpan(input);
-
-			public DateTime? GetNextExecution(DateTime? after = null)
-			{
-				return (after ?? DateTime.UtcNow).ToUniversalTime().Add(this.TimeSpan);
-			}
-
-			public string ToDashboardDisplayString()
-			{
-				return this.TimeSpan.ToDashboardDisplayString();
 			}
 		}
 	}

--- a/MFiles.VAF.Extensions/RecurringOperationConfigurationManager.cs
+++ b/MFiles.VAF.Extensions/RecurringOperationConfigurationManager.cs
@@ -148,7 +148,7 @@ namespace MFiles.VAF.Extensions
 				DateTime? nextExecution = null;
 
 				// If this should run at vault startup then run it now.
-				if (isVaultStartup && schedule.RunOnVaultStartup)
+				if (isVaultStartup && schedule.RunOnVaultStartup.HasValue && schedule.RunOnVaultStartup.Value)
 					nextExecution = DateTime.UtcNow;
 
 				// If we don't have a schedule then stop.
@@ -413,7 +413,7 @@ namespace MFiles.VAF.Extensions
 			public TimeSpan TimeSpan { get; set; }
 
 			/// <inheritdoc/>
-			public bool RunOnVaultStartup => true;
+			public bool? RunOnVaultStartup => true;
 
 			public WrappedTimeSpan(TimeSpan timeSpan)
 			{


### PR DESCRIPTION
Allows Frequency- and Schedule-based configurations to additionally be run when the vault comes online.
Also allows interval-based configurations to opt out of running when the vault comes online (by instead switching configuration values to the new `TimeSpanEx` class).