### PR TITLE
FrequencyJsonConverter

### DIFF
--- a/MFiles.VAF.Extensions.Tests/Configuration/FrequencyTests.cs
+++ b/MFiles.VAF.Extensions.Tests/Configuration/FrequencyTests.cs
@@ -1,0 +1,270 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.Serialization;
+using System.Text;
+using System.Threading.Tasks;
+
+using FluentAssertions;
+using FluentAssertions.Json;
+
+using MFiles.VAF.Extensions.ScheduledExecution;
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+
+namespace MFiles.VAF.Extensions.Tests.Configuration
+{
+	[DataContract]
+	internal class TimespanWrapper
+	{
+		[DataMember]
+		public TimeSpan Frequency { get; set; }
+	}
+
+	[DataContract]
+	internal class FrequencyWrapper
+	{
+		[DataMember]
+		public Frequency Frequency { get; set; }
+	}
+
+	[DataContract]
+	internal class TimeSpanExWrapper
+	{
+		[DataMember]
+		public TimeSpanEx Frequency { get; set; }
+	}
+
+	[DataContract]
+	internal class ScheduleWrapper
+	{
+		[DataMember]
+		public Schedule Frequency { get; set; }
+	}
+
+	[TestClass]
+	public class FrequencyTests
+	{
+		/// <summary>
+		/// Basic test to see that serialization happens correctly with the <see cref="FrequencyJsonConverter"/>
+		/// </summary>
+		[TestMethod]
+		public void SerializesCorrectly()
+		{
+			string json = JsonConvert.SerializeObject(new Frequency()
+			{
+				Interval = new TimeSpan(1, 2, 3)
+			});
+			var expected = JObject.Parse(@"{""RecurrenceType"":0,""Interval"":{ ""Interval"": ""01:02:03"",  ""RunOnVaultStartup"": true}}");
+			var output = JObject.Parse(json);
+
+			output.Should().BeEquivalentTo(expected);
+		}
+
+		/// <summary>
+		/// Basic test to see that deserialization happens correctly with the <see cref="FrequencyJsonConverter"/>
+		/// </summary>
+		[TestMethod]
+		public void DeserializesCorrectly()
+		{
+			string json = @"{""RecurrenceType"":0,""Interval"":{ ""Interval"": ""01:02:03"",  ""RunOnVaultStartup"": true}}";
+			Frequency output = JsonConvert.DeserializeObject<Frequency>(json);
+
+			Frequency expected = new Frequency()
+			{
+				Interval = new TimeSpan(1, 2, 3),
+				RecurrenceType = RecurrenceType.Unknown
+			};
+
+			output.ShouldBeEquivalentTo(expected);
+		}
+
+		/// <summary>
+		/// Check if <see cref="FrequencyJsonConverter"/> can deserialize a TimeSpan
+		/// </summary>
+		[TestMethod]
+		public void DeserializesTimeSpan()
+		{
+			TimeSpan timespan = new TimeSpan(1, 2, 3);
+			string json = JsonConvert.SerializeObject(timespan);
+
+			var output = JsonConvert.DeserializeObject<Frequency>(json);
+
+			Frequency expected = new Frequency()
+			{
+				Interval = new TimeSpan(1, 2, 3),
+				RecurrenceType = RecurrenceType.Interval
+			};
+
+			output.ShouldBeEquivalentTo(expected);
+		}
+
+		/// <summary>
+		/// Check if <see cref="FrequencyJsonConverter"/> can deserialize a TimeSpanEx
+		/// </summary>
+		[TestMethod]
+		public void DeserializesTimeSpanEx()
+		{
+			TimeSpanEx timeSpanEx = new TimeSpanEx()
+			{
+				Interval = new TimeSpan(1, 2, 3),
+				RunOnVaultStartup = false //Picked false because it's not the default value
+			};
+
+			string json = JsonConvert.SerializeObject(timeSpanEx);
+			var output = JsonConvert.DeserializeObject<Frequency>(json);
+			var expected = new Frequency()
+			{
+				Interval = new TimeSpanEx()
+				{
+					Interval = new TimeSpan(1, 2, 3),
+					RunOnVaultStartup = false
+				},
+				RecurrenceType = RecurrenceType.Interval
+			};
+
+			output.ShouldBeEquivalentTo(expected);
+		}
+
+		/// <summary>
+		/// Check if <see cref="FrequencyJsonConverter"/> can deserialize a Schedule
+		/// </summary>
+		[TestMethod]
+		public void DeserializesSchedule()
+		{
+			Schedule schedule = new Schedule()
+			{
+				Enabled = true,
+				Triggers = new List<Trigger>()
+				{
+					new Trigger(ScheduleTriggerType.Daily)
+					{
+						DailyTriggerConfiguration = new DailyTrigger()
+						{
+							TriggerTimes = new List<TimeSpan>()
+							{
+								new TimeSpan(1,2,3)
+							}
+						}
+					}
+				},
+				RunOnVaultStartup = false //Picked false because it's not the default value
+			};
+
+			string json = JsonConvert.SerializeObject(schedule);
+			var output = JsonConvert.DeserializeObject<Frequency>(json);
+			var expected = new Frequency()
+			{
+				Schedule = schedule,
+				RecurrenceType = RecurrenceType.Schedule
+			};
+
+			output.ShouldBeEquivalentTo(expected);
+		}
+
+		/// <summary>
+		/// Check if <see cref="FrequencyJsonConverter"/> can deserialize a TimeSpan contained within a wrapper class
+		/// </summary>
+		[TestMethod]
+		public void DeserializesTimeSpanWrapper()
+		{
+			var oldWrapper = new TimespanWrapper()
+			{
+				Frequency = new TimeSpan(1, 2, 3)
+			};
+
+			string json = JsonConvert.SerializeObject(oldWrapper);
+
+			var output = JsonConvert.DeserializeObject<FrequencyWrapper>(json);
+			var expected = new FrequencyWrapper()
+			{
+				Frequency = new Frequency()
+				{
+					Interval = new TimeSpan(1, 2, 3),
+					RecurrenceType = RecurrenceType.Interval
+				}
+			};
+
+			output.ShouldBeEquivalentTo(expected);
+		}
+
+		/// <summary>
+		/// Check if <see cref="FrequencyJsonConverter"/> can deserialize a TimeSpanEx contained within a wrapper class
+		/// </summary>
+		[TestMethod]
+		public void DeserializesTimeSpanExWrapper()
+		{
+			var timeSpanEx = new TimeSpanEx()
+			{
+				Interval = new TimeSpan(1, 2, 3),
+				RunOnVaultStartup = false
+			};
+			var oldWrapper = new TimeSpanExWrapper()
+			{
+				Frequency = timeSpanEx
+			};
+
+			string json = JsonConvert.SerializeObject(oldWrapper);
+
+			var output = JsonConvert.DeserializeObject<FrequencyWrapper>(json);
+			var expected = new FrequencyWrapper()
+			{
+				Frequency = new Frequency()
+				{
+					Interval = timeSpanEx,
+					RecurrenceType = RecurrenceType.Interval
+				}
+			};
+
+			output.ShouldBeEquivalentTo(expected);
+		}
+
+		/// <summary>
+		/// Check if <see cref="FrequencyJsonConverter"/> can deserialize a Schedule contained within a wrapper class
+		/// </summary>
+		[TestMethod]
+		public void DeserializesScheduleWrapper()
+		{
+			Schedule schedule = new Schedule()
+			{
+				Enabled = true,
+				Triggers = new List<Trigger>()
+				{
+					new Trigger(ScheduleTriggerType.Daily)
+					{
+						DailyTriggerConfiguration = new DailyTrigger()
+						{
+							TriggerTimes = new List<TimeSpan>()
+							{
+								new TimeSpan(1,2,3)
+							}
+						}
+					}
+				},
+				RunOnVaultStartup = false //Picked false because it's not the default value
+			};
+			var oldWrapper = new ScheduleWrapper()
+			{
+				Frequency = schedule
+			};
+
+			string json = JsonConvert.SerializeObject(oldWrapper);
+
+			var output = JsonConvert.DeserializeObject<FrequencyWrapper>(json);
+			var expected = new FrequencyWrapper()
+			{
+				Frequency = new Frequency()
+				{
+					Schedule = schedule,
+					RecurrenceType = RecurrenceType.Schedule
+				}
+			};
+
+			output.ShouldBeEquivalentTo(expected);
+
+		}
+	}
+}

--- a/MFiles.VAF.Extensions.Tests/Configuration/FrequencyTests.cs
+++ b/MFiles.VAF.Extensions.Tests/Configuration/FrequencyTests.cs
@@ -5,9 +5,6 @@ using System.Runtime.Serialization;
 using System.Text;
 using System.Threading.Tasks;
 
-using FluentAssertions;
-using FluentAssertions.Json;
-
 using MFiles.VAF.Extensions.ScheduledExecution;
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;
@@ -54,14 +51,15 @@ namespace MFiles.VAF.Extensions.Tests.Configuration
 		[TestMethod]
 		public void SerializesCorrectly()
 		{
-			string json = JsonConvert.SerializeObject(new Frequency()
+			var frequency = new Frequency()
 			{
 				Interval = new TimeSpan(1, 2, 3)
-			});
-			var expected = JObject.Parse(@"{""RecurrenceType"":0,""Interval"":{ ""Interval"": ""01:02:03"",  ""RunOnVaultStartup"": true}}");
-			var output = JObject.Parse(json);
+			};
+			var expected = JToken.Parse("{\"RecurrenceType\":0,\"Interval\":{\r\n  \"Interval\": \"01:02:03\",\r\n  \"RunOnVaultStartup\": true\r\n}}");
+			var output = JToken.Parse(JsonConvert.SerializeObject(frequency));
 
-			output.Should().BeEquivalentTo(expected);
+			Assert.AreEqual(JsonConvert.SerializeObject(expected), JsonConvert.SerializeObject(output));
+			//output.Should().BeEquivalentTo(expected);
 		}
 
 		/// <summary>
@@ -79,7 +77,8 @@ namespace MFiles.VAF.Extensions.Tests.Configuration
 				RecurrenceType = RecurrenceType.Unknown
 			};
 
-			output.ShouldBeEquivalentTo(expected);
+			Assert.AreEqual(JsonConvert.SerializeObject(expected), JsonConvert.SerializeObject(output));
+			//output.ShouldBeEquivalentTo(expected);
 		}
 
 		/// <summary>
@@ -99,7 +98,8 @@ namespace MFiles.VAF.Extensions.Tests.Configuration
 				RecurrenceType = RecurrenceType.Interval
 			};
 
-			output.ShouldBeEquivalentTo(expected);
+			Assert.AreEqual(JsonConvert.SerializeObject(expected), JsonConvert.SerializeObject(output));
+			//output.ShouldBeEquivalentTo(expected);
 		}
 
 		/// <summary>
@@ -126,7 +126,8 @@ namespace MFiles.VAF.Extensions.Tests.Configuration
 				RecurrenceType = RecurrenceType.Interval
 			};
 
-			output.ShouldBeEquivalentTo(expected);
+			Assert.AreEqual(JsonConvert.SerializeObject(expected), JsonConvert.SerializeObject(output));
+			//output.ShouldBeEquivalentTo(expected);
 		}
 
 		/// <summary>
@@ -162,7 +163,8 @@ namespace MFiles.VAF.Extensions.Tests.Configuration
 				RecurrenceType = RecurrenceType.Schedule
 			};
 
-			output.ShouldBeEquivalentTo(expected);
+			Assert.AreEqual(JsonConvert.SerializeObject(expected), JsonConvert.SerializeObject(output));
+			//output.ShouldBeEquivalentTo(expected);
 		}
 
 		/// <summary>
@@ -188,7 +190,8 @@ namespace MFiles.VAF.Extensions.Tests.Configuration
 				}
 			};
 
-			output.ShouldBeEquivalentTo(expected);
+			Assert.AreEqual(JsonConvert.SerializeObject(expected), JsonConvert.SerializeObject(output));
+			//output.ShouldBeEquivalentTo(expected);
 		}
 
 		/// <summary>
@@ -219,7 +222,8 @@ namespace MFiles.VAF.Extensions.Tests.Configuration
 				}
 			};
 
-			output.ShouldBeEquivalentTo(expected);
+			Assert.AreEqual(JsonConvert.SerializeObject(expected), JsonConvert.SerializeObject(output));
+			//output.ShouldBeEquivalentTo(expected);
 		}
 
 		/// <summary>
@@ -263,8 +267,8 @@ namespace MFiles.VAF.Extensions.Tests.Configuration
 				}
 			};
 
-			output.ShouldBeEquivalentTo(expected);
-
+			Assert.AreEqual(JsonConvert.SerializeObject(expected), JsonConvert.SerializeObject(output));
+			//output.ShouldBeEquivalentTo(expected);
 		}
 	}
 }

--- a/MFiles.VAF.Extensions.Tests/MFiles.VAF.Extensions.Tests.csproj
+++ b/MFiles.VAF.Extensions.Tests/MFiles.VAF.Extensions.Tests.csproj
@@ -13,6 +13,8 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="FluentAssertions" Version="4.19.0" />
+    <PackageReference Include="FluentAssertions.Json" Version="4.20.1" />
     <PackageReference Include="MFiles.VAF" Version="2.3.623.2" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />
     <PackageReference Include="Moq" Version="4.13.1" />

--- a/MFiles.VAF.Extensions.Tests/MFiles.VAF.Extensions.Tests.csproj
+++ b/MFiles.VAF.Extensions.Tests/MFiles.VAF.Extensions.Tests.csproj
@@ -13,8 +13,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="FluentAssertions" Version="4.19.0" />
-    <PackageReference Include="FluentAssertions.Json" Version="4.20.1" />
     <PackageReference Include="MFiles.VAF" Version="2.3.623.2" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />
     <PackageReference Include="Moq" Version="4.13.1" />


### PR DESCRIPTION
Possible solution to #44.

I added a FrequencyJsonConverter class and decorated the Frequency class with it.
I then wrote a number of test to show that it can convert from a TimeSpan, TimeSpanEx and Schedule, both naturally and within a wrapper class.

I'm checking whether something might be a TimeSpanEx or Schedule object by checking the properties of the JToken. This might not be the best way, but I'm not certain how else it could be done.

I also added the FluentAssertions nuget package to the test project because they had methods for checking JToken equivalency.

As an added bonus using these methods gives a clearer error message if a test fails.
I can remove this package if this is necessary.