### PR TITLE
Allow recurring task schedules in different timezones

### DIFF
--- a/MFiles.VAF.Extensions.Tests/Configuration/ScheduledExecution/DailyTriggerTests.cs
+++ b/MFiles.VAF.Extensions.Tests/Configuration/ScheduledExecution/DailyTriggerTests.cs
@@ -82,11 +82,19 @@ namespace MFiles.VAF.Extensions.Tests.ScheduledExecution
 				(DateTime?)null
 			};
 
-			// Exact current time returns next day.
+			// Exact current time now.
 			yield return new object[]
 			{
 				new []{ new TimeSpan(17, 0, 0) },
 				new DateTime(2021, 03, 17, 17, 00, 00), // Wednesday @ 6pm
+				new DateTime(2021, 03, 17, 17, 00, 00), // Thursday @ midnight
+			};
+
+			// One minute past returns next day.
+			yield return new object[]
+			{
+				new []{ new TimeSpan(17, 0, 0) },
+				new DateTime(2021, 03, 17, 17, 01, 00), // Wednesday @ 6pm
 				new DateTime(2021, 03, 18, 17, 00, 00), // Thursday @ midnight
 			};
 		}

--- a/MFiles.VAF.Extensions.Tests/Configuration/ScheduledExecution/DailyTriggerTests.cs
+++ b/MFiles.VAF.Extensions.Tests/Configuration/ScheduledExecution/DailyTriggerTests.cs
@@ -25,14 +25,11 @@ namespace MFiles.VAF.Extensions.Tests.ScheduledExecution
 			DateTime? expected
 		)
 		{
-			Assert.AreEqual
-			(
-				expected,
-				new DailyTrigger()
-				{
-					TriggerTimes = triggerTimes.ToList()
-				}.GetNextExecution(after)
-			);
+			var execution = new DailyTrigger()
+			{
+				TriggerTimes = triggerTimes.ToList()
+			}.GetNextExecution(after);
+			Assert.AreEqual(expected?.ToUniversalTime(), execution?.ToUniversalTime());
 		}
 
 		public static IEnumerable<object[]> GetNextExecutionData()

--- a/MFiles.VAF.Extensions.Tests/Configuration/ScheduledExecution/DayOfMonthTriggerTests.cs
+++ b/MFiles.VAF.Extensions.Tests/Configuration/ScheduledExecution/DayOfMonthTriggerTests.cs
@@ -47,15 +47,12 @@ namespace MFiles.VAF.Extensions.Tests.ScheduledExecution
 			DateTime? expected
 		)
 		{
-			Assert.AreEqual
-			(
-				expected,
-				new DayOfMonthTrigger()
-				{
-					TriggerTimes = triggerTimes.ToList(),
-					TriggerDays = triggerDays.ToList()
-				}.GetNextExecution(after)
-			);
+			var execution = new DayOfMonthTrigger()
+			{
+				TriggerTimes = triggerTimes.ToList(),
+				TriggerDays = triggerDays.ToList()
+			}.GetNextExecution(after);
+			Assert.AreEqual(expected?.ToUniversalTime(), execution?.ToUniversalTime());
 		}
 
 		public static IEnumerable<object[]> GetNextExecutionData()

--- a/MFiles.VAF.Extensions.Tests/Configuration/ScheduledExecution/ScheduleTests.cs
+++ b/MFiles.VAF.Extensions.Tests/Configuration/ScheduledExecution/ScheduleTests.cs
@@ -49,6 +49,27 @@ namespace MFiles.VAF.Extensions.Tests.ScheduledExecution
 
 		[TestMethod]
 		[DynamicData(nameof(GetNextExecutionData), DynamicDataSourceType.Method)]
+		public void GetNextExecution_UTC
+		(
+			IEnumerable<TriggerBase> triggers,
+			DateTime? after,
+			DateTime? expected
+		)
+		{
+			var execution = new Schedule()
+			{
+				Enabled = true,
+				Triggers = triggers
+						.Select(t => new Trigger(t))
+						.Where(t => t != null)
+						.ToList(),
+				TriggerTimeType = TriggerTimeType.Utc
+			}.GetNextExecution(after);
+			Assert.AreEqual(expected?.ToUniversalTime(), execution?.ToUniversalTime());
+		}
+
+		[TestMethod]
+		[DynamicData(nameof(GetNextExecutionData), DynamicDataSourceType.Method)]
 		public void GetNextExecution_NotEnabled
 		(
 			IEnumerable<TriggerBase> triggers,
@@ -68,7 +89,8 @@ namespace MFiles.VAF.Extensions.Tests.ScheduledExecution
 					Triggers = triggers
 						.Select(t => new Trigger(t))
 						.Where(t => t != null)
-						.ToList()
+						.ToList(),
+					TriggerTimeType = TriggerTimeType.Utc
 				}.GetNextExecution(after)
 			);
 		}

--- a/MFiles.VAF.Extensions.Tests/Configuration/ScheduledExecution/ScheduleTests.cs
+++ b/MFiles.VAF.Extensions.Tests/Configuration/ScheduledExecution/ScheduleTests.cs
@@ -25,7 +25,7 @@ namespace MFiles.VAF.Extensions.Tests.ScheduledExecution
 		}
 
 		[TestMethod]
-		[DynamicData(nameof(GetNextExecutionData), DynamicDataSourceType.Method)]
+		[DynamicData(nameof(GetNextExecutionData_UTC), DynamicDataSourceType.Method)]
 		public void GetNextExecution
 		(
 			IEnumerable<TriggerBase> triggers,
@@ -70,7 +70,73 @@ namespace MFiles.VAF.Extensions.Tests.ScheduledExecution
 		}
 
 		[TestMethod]
-		[DynamicData(nameof(GetNextExecutionData), DynamicDataSourceType.Method)]
+		[DynamicData(nameof(GetNextExecutionData_AusEastern), DynamicDataSourceType.Method)]
+		public void GetNextExecution_AusEastern
+		(
+			IEnumerable<TriggerBase> triggers,
+			DateTime? after,
+			DateTime? expected
+		)
+		{
+			var execution = new Schedule()
+			{
+				Enabled = true,
+				Triggers = triggers
+						.Select(t => new Trigger(t))
+						.Where(t => t != null)
+						.ToList(),
+				TriggerTimeType = TriggerTimeType.Custom,
+				TriggerTimeCustomTimeZone = "AUS Eastern Standard Time"
+			}.GetNextExecution(after);
+			Assert.AreEqual(expected?.ToUniversalTime(), execution?.ToUniversalTime());
+		}
+
+		[TestMethod]
+		[DynamicData(nameof(GetNextExecutionData_PacificStandard), DynamicDataSourceType.Method)]
+		public void GetNextExecution_PacificStandard
+		(
+			IEnumerable<TriggerBase> triggers,
+			DateTime? after,
+			DateTime? expected
+		)
+		{
+			var execution = new Schedule()
+			{
+				Enabled = true,
+				Triggers = triggers
+						.Select(t => new Trigger(t))
+						.Where(t => t != null)
+						.ToList(),
+				TriggerTimeType = TriggerTimeType.Custom,
+				TriggerTimeCustomTimeZone = "Pacific Standard Time"
+			}.GetNextExecution(after);
+			Assert.AreEqual(expected?.ToUniversalTime(), execution?.ToUniversalTime());
+		}
+
+		[TestMethod]
+		[DynamicData(nameof(GetNextExecutionData_GMT), DynamicDataSourceType.Method)]
+		public void GetNextExecution_GMT
+		(
+			IEnumerable<TriggerBase> triggers,
+			DateTime? after,
+			DateTime? expected
+		)
+		{
+			var execution = new Schedule()
+			{
+				Enabled = true,
+				Triggers = triggers
+						.Select(t => new Trigger(t))
+						.Where(t => t != null)
+						.ToList(),
+				TriggerTimeType = TriggerTimeType.Custom,
+				TriggerTimeCustomTimeZone = "GMT Standard Time"
+			}.GetNextExecution(after);
+			Assert.AreEqual(expected?.ToUniversalTime(), execution?.ToUniversalTime());
+		}
+
+		[TestMethod]
+		[DynamicData(nameof(GetNextExecutionData_UTC), DynamicDataSourceType.Method)]
 		public void GetNextExecution_NotEnabled
 		(
 			IEnumerable<TriggerBase> triggers,
@@ -96,7 +162,7 @@ namespace MFiles.VAF.Extensions.Tests.ScheduledExecution
 			);
 		}
 
-		public static IEnumerable<object[]> GetNextExecutionData()
+		public static IEnumerable<object[]> GetNextExecutionData_UTC()
 		{
 			// Single trigger.
 			yield return new object[]
@@ -110,8 +176,8 @@ namespace MFiles.VAF.Extensions.Tests.ScheduledExecution
 						}.ToList()
 					}
 				},
-				new DateTime(2021, 03, 17, 01, 00, 00), // Wednesday @ 1am
-				new DateTime(2021, 03, 17, 17, 00, 00), // Wednesday @ 5pm
+				new DateTime(2021, 03, 17, 01, 00, 00, DateTimeKind.Utc), // Wednesday @ 1am
+				new DateTime(2021, 03, 17, 17, 00, 00, DateTimeKind.Utc), // Wednesday @ 5pm
 			};
 
 			// Multiple triggers returns earliest.
@@ -132,15 +198,15 @@ namespace MFiles.VAF.Extensions.Tests.ScheduledExecution
 						}.ToList()
 					}
 				},
-				new DateTime(2021, 03, 17, 01, 00, 00), // Wednesday @ 1am
-				new DateTime(2021, 03, 17, 12, 00, 00), // Wednesday @ 5pm
+				new DateTime(2021, 03, 17, 01, 00, 00, DateTimeKind.Utc), // Wednesday @ 1am
+				new DateTime(2021, 03, 17, 12, 00, 00, DateTimeKind.Utc), // Wednesday @ 5pm
 			};
 
 			// No triggers = null.
 			yield return new object[]
 			{
 				new TriggerBase[0],
-				new DateTime(2021, 03, 17, 01, 00, 00), // Wednesday @ 1am
+				new DateTime(2021, 03, 17, 01, 00, 00, DateTimeKind.Utc), // Wednesday @ 1am
 				(DateTime?)null
 			};
 
@@ -156,13 +222,130 @@ namespace MFiles.VAF.Extensions.Tests.ScheduledExecution
 						}.ToList()
 					}
 				},
-				new DateTime(2021, 03, 17, 17, 00, 00), // Wednesday @ 1am
-				new DateTime(2021, 03, 17, 17, 00, 00)
+				new DateTime(2021, 03, 17, 17, 00, 00, DateTimeKind.Utc), // Wednesday @ 1am
+				new DateTime(2021, 03, 17, 17, 00, 00, DateTimeKind.Utc)
 			};
 		}
 
 		/// <summary>
-		/// This is the same data as <see cref="GetNextExecutionData"/>, but the
+		/// Check what happens at daylight saving changes
+		/// </summary>
+		/// <returns></returns>
+		public static IEnumerable<object[]> GetNextExecutionData_GMT()
+		{
+			// Just before clocks go forward.
+			yield return new object[]
+			{
+				new TriggerBase[]
+				{
+					new DailyTrigger(){
+						TriggerTimes = new List<TimeSpan>()
+						{
+							new TimeSpan(1, 30, 0) // The trigger for 0130 is because this is between when the clocks change
+						}.ToList()
+					}
+				},
+				new DateTime(2022, 03, 26, 00, 00, 00, DateTimeKind.Utc), // This is still in GMT (UTC+0)
+				new DateTime(2022, 03, 26, 01, 30, 00, DateTimeKind.Utc), // So it should run at 0130 UTC
+			};
+
+			// Just after clocks go forward.
+			yield return new object[]
+			{
+				new TriggerBase[]
+				{
+					new DailyTrigger(){
+						TriggerTimes = new List<TimeSpan>()
+						{
+							new TimeSpan(1, 30, 0) // The trigger for 0130 is because this is between when the clocks change
+						}.ToList()
+					}
+				},
+				new DateTime(2022, 03, 27, 02, 01, 00, DateTimeKind.Utc), // The next run time will be in BST (UTC+1)
+				new DateTime(2022, 03, 28, 00, 30, 00, DateTimeKind.Utc), // Check that it runs at 0030 the next day.
+			};
+
+			// Just before clocks go backwards.
+			yield return new object[]
+			{
+				new TriggerBase[]
+				{
+					new DailyTrigger(){
+						TriggerTimes = new List<TimeSpan>()
+						{
+							new TimeSpan(1, 30, 0) // The trigger for 0130 is because this is between when the clocks change
+						}.ToList()
+					}
+				},
+				new DateTime(2022, 10, 30, 00, 00, 00, DateTimeKind.Utc), // This is 0100 BST
+				new DateTime(2022, 10, 30, 00, 30, 00, DateTimeKind.Utc), // So it should run at 0030UTC / 0130 BST
+			};
+
+			// Just after clocks go backwards.
+			yield return new object[]
+			{
+				new TriggerBase[]
+				{
+					new DailyTrigger(){
+						TriggerTimes = new List<TimeSpan>()
+						{
+							new TimeSpan(1, 30, 0) // The trigger for 0130 is because this is between when the clocks change
+						}.ToList()
+					}
+				},
+				new DateTime(2022, 10, 30, 02, 01, 00, DateTimeKind.Utc), // This is 0301 in GMT
+				new DateTime(2022, 10, 31, 01, 30, 00, DateTimeKind.Utc), // Check that it runs at 0130 the next day.
+			};
+		}
+
+		/// <summary>
+		/// Returns data for a high UTC offset where the trigger times are the previous day in UTC.
+		/// </summary>
+		/// <returns></returns>
+		public static IEnumerable<object[]> GetNextExecutionData_AusEastern()
+		{
+			// Single trigger.
+			yield return new object[]
+			{
+				new TriggerBase[]
+				{
+					new DailyTrigger(){
+						TriggerTimes = new List<TimeSpan>()
+						{
+							new TimeSpan(5, 0, 0) // 5am Aus Eastern is UTC+10, so this should equate to the previous day in UTC.
+						}.ToList()
+					}
+				},
+				new DateTime(2021, 08, 18, 18, 00, 00, DateTimeKind.Utc), // This is two hours before the time it should run
+				new DateTime(2021, 08, 18, 19, 00, 00, DateTimeKind.Utc), // This is 5am on the 19th in Sydney
+			};
+		}
+
+		/// <summary>
+		/// Returns data for a high UTC offset where the trigger times are the next day in UTC.
+		/// </summary>
+		/// <returns></returns>
+		public static IEnumerable<object[]> GetNextExecutionData_PacificStandard()
+		{
+			// Single trigger.
+			yield return new object[]
+			{
+				new TriggerBase[]
+				{
+					new DailyTrigger(){
+						TriggerTimes = new List<TimeSpan>()
+						{
+							new TimeSpan(22, 30, 0) // 2230 Pacific Standard is UTC-8, so this should equate to the next day in UTC.
+						}.ToList()
+					}
+				},
+				new DateTime(2021, 08, 18, 20, 30, 00, DateTimeKind.Utc), // This is two hours before the time it should run
+				new DateTime(2021, 08, 19, 05, 30, 00, DateTimeKind.Utc), // This is 1030pm on the 18th in LA
+			};
+		}
+
+		/// <summary>
+		/// This is the same data as <see cref="GetNextExecutionData_UTC"/>, but the
 		/// trigger times are expected to be in Finnish timezone (UTC+2), so the resulting
 		/// times should be accordingly offset.
 		/// </summary>
@@ -264,7 +447,7 @@ namespace MFiles.VAF.Extensions.Tests.ScheduledExecution
 			};
 			Assert.AreEqual
 			(
-				"<p>Runs according to the following schedule:<ul><li>Daily at the following times: 01:30:32.</li></ul></p>",
+				"<p>Runs according to the following schedule:<ul><li>Daily at the following times: 01:30:32 (server time).</li></ul></p>",
 				schedule.ToDashboardDisplayString()
 			);
 		}
@@ -285,7 +468,7 @@ namespace MFiles.VAF.Extensions.Tests.ScheduledExecution
 			};
 			Assert.AreEqual
 			(
-				"<p>Runs when the vault starts and according to the following schedule:<ul><li>Daily at the following times: 01:30:32.</li></ul></p>",
+				"<p>Runs when the vault starts and according to the following schedule:<ul><li>Daily at the following times: 01:30:32 (server time).</li></ul></p>",
 				schedule.ToDashboardDisplayString()
 			);
 		}

--- a/MFiles.VAF.Extensions.Tests/Configuration/ScheduledExecution/WeeklyTriggerTests.cs
+++ b/MFiles.VAF.Extensions.Tests/Configuration/ScheduledExecution/WeeklyTriggerTests.cs
@@ -44,15 +44,12 @@ namespace MFiles.VAF.Extensions.Tests.ScheduledExecution
 			DateTime? expected
 		)
 		{
-			Assert.AreEqual
-			(
-				expected,
-				new WeeklyTrigger()
-				{
-					TriggerTimes = triggerTimes.ToList().ToList(),
-					TriggerDays = triggerDays.ToList()
-				}.GetNextExecution(after)
-			);
+			var execution = new WeeklyTrigger()
+			{
+				TriggerTimes = triggerTimes.ToList().ToList(),
+				TriggerDays = triggerDays.ToList()
+			}.GetNextExecution(after);
+			Assert.AreEqual(expected?.ToUniversalTime(), execution?.ToUniversalTime());
 		}
 
 		public static IEnumerable<object[]> GetNextExecutionData()

--- a/MFiles.VAF.Extensions/ConfigurableVaultApplicationBase.GetDashboardContent.cs
+++ b/MFiles.VAF.Extensions/ConfigurableVaultApplicationBase.GetDashboardContent.cs
@@ -264,7 +264,7 @@ namespace MFiles.VAF.Extensions
 				Title = Resources.Dashboard.AsynchronousOperations_DashboardTitle,
 				InnerContent = new DashboardContentCollection
 				{
-					new DashboardCustomContent($"<em>{Resources.Dashboard.TimeOnServer.EscapeXmlForDashboard(DateTime.Now.ToLocalTime().ToString("HH:mm:ss"))}</em>"),
+					new DashboardCustomContent($"<em>{Resources.Dashboard.TimeOnServer.EscapeXmlForDashboard(DateTime.Now.ToLocalTime().ToString("HH:mm:ss"))} ({TimeZoneInfo.Local.DisplayName})</em>"),
 					list
 				}
 			};

--- a/MFiles.VAF.Extensions/ConfigurableVaultApplicationBase.GetDashboardContent.cs
+++ b/MFiles.VAF.Extensions/ConfigurableVaultApplicationBase.GetDashboardContent.cs
@@ -264,7 +264,7 @@ namespace MFiles.VAF.Extensions
 				Title = Resources.Dashboard.AsynchronousOperations_DashboardTitle,
 				InnerContent = new DashboardContentCollection
 				{
-					new DashboardCustomContent($"<em>{Resources.Dashboard.TimeOnServer.EscapeXmlForDashboard(DateTime.Now.ToLocalTime().ToString("HH:mm:ss"))} ({TimeZoneInfo.Local.DisplayName})</em>"),
+					new DashboardCustomContent($"<em>{Resources.Dashboard.TimeOnServer.EscapeXmlForDashboard(DateTime.Now.ToLocalTime().ToString("HH:mm:ss"))} ({(TimeZoneInfo.Local.IsDaylightSavingTime(DateTime.Now) ? TimeZoneInfo.Local.DaylightName : TimeZoneInfo.Local.StandardName)})</em>"),
 					list
 				}
 			};

--- a/MFiles.VAF.Extensions/Configuration/Frequency.cs
+++ b/MFiles.VAF.Extensions/Configuration/Frequency.cs
@@ -68,7 +68,7 @@ namespace MFiles.VAF.Extensions
 		}
 
 		/// <inheritdoc />
-		public DateTime? GetNextExecution(DateTime? after = null)
+		public DateTimeOffset? GetNextExecution(DateTime? after = null)
 		{
 			switch (this.RecurrenceType)
 			{

--- a/MFiles.VAF.Extensions/Configuration/IRecurrenceConfiguration.cs
+++ b/MFiles.VAF.Extensions/Configuration/IRecurrenceConfiguration.cs
@@ -11,12 +11,12 @@ namespace MFiles.VAF.Extensions
 		/// <example>&lt;p&gt;Runs every 10 minutes.&lt;/p&gt;</example>
 		string ToDashboardDisplayString();
 
-		/// <summary>
-		/// Returns the next time the recurrence should run.
-		/// </summary>
-		/// <param name="after">The current execution time, or null to use the current time.</param>
-		/// <returns>The next-run time.  May be null if there are no valid next-run times.</returns>
-		DateTime? GetNextExecution(DateTime? after = null);
+        /// <summary>
+        /// Returns the next time the recurrence should run.
+        /// </summary>
+        /// <param name="after">The current execution time, or null to use the current time.</param>
+        /// <returns>The next-run time.  May be null if there are no valid next-run times.</returns>
+        DateTimeOffset? GetNextExecution(DateTime? after = null);
 
 		/// <summary>
 		/// Whether the processor should run on vault startup (in addition to any other schedule or interval).

--- a/MFiles.VAF.Extensions/Configuration/ScheduledExecution/DailyTrigger.cs
+++ b/MFiles.VAF.Extensions/Configuration/ScheduledExecution/DailyTrigger.cs
@@ -61,7 +61,19 @@ namespace MFiles.VAF.Extensions.ScheduledExecution
 						if (after.Value.TimeOfDay <= t)
 							output = output.Add(t); // Time is yet to come today (or is now).
 						else
-							output = output.AddDays(1).Add(t); // Time has passed - return tomorrow.
+						{
+							// If the next day has gone to/from DST then we need to deal with it.
+							var oldoffset = timeZoneInfo.GetUtcOffset(output);
+							output = output.AddDays(1);
+							var newoffset = timeZoneInfo.GetUtcOffset(output);
+							if(oldoffset != newoffset)
+							{
+								output = output.Subtract(newoffset - oldoffset);
+							}
+
+							// Add on the correct time, now for the subsequent day.
+							output = output.Add(t);
+						}
 						return output;
 					}
 				)

--- a/MFiles.VAF.Extensions/Configuration/ScheduledExecution/DailyTrigger.cs
+++ b/MFiles.VAF.Extensions/Configuration/ScheduledExecution/DailyTrigger.cs
@@ -71,13 +71,22 @@ namespace MFiles.VAF.Extensions.ScheduledExecution
 		}
 
 		/// <inheritdoc />
-		public override string ToString()
+		public virtual string ToString(TriggerTimeType triggerTimeType, TimeZoneInfo customTimeZone)
 		{
 			// Sanity.
 			if (null == this.TriggerTimes || this.TriggerTimes.Count == 0)
 				return null;
 
-			return Resources.Schedule.Triggers_DailyTrigger.EscapeXmlForDashboard(string.Join(", ", this.TriggerTimes.OrderBy(t => t).Select(t => t.ToString())));
+			// Append the time zone if we can.
+			var times = string.Join(", ", this.TriggerTimes.OrderBy(t => t).Select(t => t.ToString()));
+			if (customTimeZone != null)
+				if (customTimeZone == TimeZoneInfo.Local)
+					times += " (server time)";
+				else if (customTimeZone == TimeZoneInfo.Utc)
+					times += " (UTC)";
+				else
+					times += $" ({customTimeZone.DisplayName})";
+			return Resources.Schedule.Triggers_DailyTrigger.EscapeXmlForDashboard(times);
 		}
 
 		/// <summary>

--- a/MFiles.VAF.Extensions/Configuration/ScheduledExecution/DayOfMonthTrigger.cs
+++ b/MFiles.VAF.Extensions/Configuration/ScheduledExecution/DayOfMonthTrigger.cs
@@ -187,7 +187,7 @@ namespace MFiles.VAF.Extensions.ScheduledExecution
 		}
 
 		/// <inheritdoc />
-		public override string ToString()
+		public override string ToString(TriggerTimeType triggerTimeType, TimeZoneInfo customTimeZone)
 		{
 			// Sanity.
 			if (null == this.TriggerDays || this.TriggerDays.Count == 0)
@@ -195,10 +195,19 @@ namespace MFiles.VAF.Extensions.ScheduledExecution
 			if (null == this.TriggerTimes || this.TriggerTimes.Count == 0)
 				return null;
 
+			// Append the time zone if we can.
+			var times = string.Join(", ", this.TriggerTimes.OrderBy(t => t).Select(t => t.ToString()));
+			if (customTimeZone != null)
+				if (customTimeZone == TimeZoneInfo.Local)
+					times += " (server time)";
+				else if (customTimeZone == TimeZoneInfo.Utc)
+					times += " (UTC)";
+				else
+					times += $" ({customTimeZone.DisplayName})";
 			return Resources.Schedule.Triggers_DayOfMonthTrigger.EscapeXmlForDashboard
 				(
 					string.Join(", ", this.TriggerDays.OrderBy(t => t)),
-					string.Join(", ", this.TriggerTimes.OrderBy(t => t).Select(t => t.ToString()))
+					times
 				);
 		}
 	}

--- a/MFiles.VAF.Extensions/Configuration/ScheduledExecution/DayOfMonthTrigger.cs
+++ b/MFiles.VAF.Extensions/Configuration/ScheduledExecution/DayOfMonthTrigger.cs
@@ -62,7 +62,7 @@ namespace MFiles.VAF.Extensions.ScheduledExecution
 		}
 
 		/// <inheritdoc />
-		public override DateTime? GetNextExecution(DateTime? after = null)
+		public override DateTimeOffset? GetNextExecution(DateTime? after = null, TimeZoneInfo timeZoneInfo = null)
 		{
 			// Sanity.
 			if (
@@ -73,7 +73,10 @@ namespace MFiles.VAF.Extensions.ScheduledExecution
 				return null;
 
 			// When should we start looking?
-			after = (after ?? DateTime.UtcNow).ToLocalTime();
+			after = (after ?? DateTime.UtcNow).ToUniversalTime();
+
+			// Convert the time into the timezone we're after.
+			after = TimeZoneInfo.ConvertTime(after.Value, timeZoneInfo ?? TimeZoneInfo.Local);
 
 			// Get the times to run, filtered to those in the future.
 			return this.TriggerDays
@@ -81,9 +84,21 @@ namespace MFiles.VAF.Extensions.ScheduledExecution
 				(
 					d => GetNextDayOfMonth(after.Value, d, this.UnrepresentableDateHandling)
 				)
-				.SelectMany(d => this.TriggerTimes.Select(t => d.Add(t)))
+				.SelectMany
+				(
+					d => this.TriggerTimes.Select
+					(
+						t =>
+						{
+							var output = new DateTimeOffset(d, (timeZoneInfo ?? TimeZoneInfo.Local).GetUtcOffset(d));
+							output = output.Date.Add(t); // Time is yet to come today.
+							return output;
+						}
+					)
+				)
 				.Where(d => d > after.Value)
 				.OrderBy(d => d)
+				.Select(d => d.ToUniversalTime())
 				.FirstOrDefault();
 		}
 

--- a/MFiles.VAF.Extensions/Configuration/ScheduledExecution/Schedule.cs
+++ b/MFiles.VAF.Extensions/Configuration/ScheduledExecution/Schedule.cs
@@ -67,7 +67,8 @@ namespace MFiles.VAF.Extensions.ScheduledExecution
 			HelpText = ResourceMarker.Id + nameof(Resources.Configuration.Schedule_TriggerTimeCustomTimeZone_HelpText),
 			TypeEditor = "options",
 			Hidden = true,
-			ShowWhen = ".parent._children{.key == 'TriggerTimeType' && .value == 'Custom' }"
+			ShowWhen = ".parent._children{.key == 'TriggerTimeType' && .value == 'Custom' }",
+			DefaultValue = "UTC"
 		)]
 		[ValueOptions(typeof(TimeZoneStableValueOptionsProvider))]
 		public string TriggerTimeCustomTimeZone { get; set; } = "UTC";

--- a/MFiles.VAF.Extensions/Configuration/ScheduledExecution/Schedule.cs
+++ b/MFiles.VAF.Extensions/Configuration/ScheduledExecution/Schedule.cs
@@ -53,6 +53,8 @@ namespace MFiles.VAF.Extensions.ScheduledExecution
 		[DataMember]
 		[JsonConfEditor
 		(
+			Label = ResourceMarker.Id + nameof(Resources.Configuration.Schedule_TriggerTimeType_Label),
+			HelpText = ResourceMarker.Id + nameof(Resources.Configuration.Schedule_TriggerTimeType_HelpText),
 			DefaultValue = TriggerTimeType.ServerTime
 		)]
 		public TriggerTimeType TriggerTimeType { get; set; } = TriggerTimeType.ServerTime;
@@ -61,13 +63,15 @@ namespace MFiles.VAF.Extensions.ScheduledExecution
 		[DataMember]
 		[JsonConfEditor
 		(
+			Label = ResourceMarker.Id + nameof(Resources.Configuration.Schedule_TriggerTimeCustomTimeZone_Label),
+			HelpText = ResourceMarker.Id + nameof(Resources.Configuration.Schedule_TriggerTimeCustomTimeZone_HelpText),
 			TypeEditor = "options",
 			Hidden = true,
 			ShowWhen = ".parent._children{.key == 'TriggerTimeType' && .value == 'Custom' }"
 		)]
 		[ValueOptions(typeof(TimeZoneStableValueOptionsProvider))]
-		public string TriggerTimeCustomTimeZone { get; set; }
-		public bool ShouldSerializeTriggerTimeCustomTimeZone() => !string.IsNullOrWhiteSpace(this.TriggerTimeCustomTimeZone);
+		public string TriggerTimeCustomTimeZone { get; set; } = "UTC";
+		public bool ShouldSerializeTriggerTimeCustomTimeZone() => !string.IsNullOrWhiteSpace(this.TriggerTimeCustomTimeZone) && this.TriggerTimeCustomTimeZone != "UTC";
 
 		/// <summary>
 		/// Gets the next execution datetime for this trigger.

--- a/MFiles.VAF.Extensions/Configuration/ScheduledExecution/TimeZoneStableValueOptionsProvider.cs
+++ b/MFiles.VAF.Extensions/Configuration/ScheduledExecution/TimeZoneStableValueOptionsProvider.cs
@@ -1,0 +1,26 @@
+﻿using MFiles.VAF.Configuration.AdminConfigurations;
+using MFiles.VAF.Configuration.JsonEditor;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace MFiles.VAF.Extensions.Configuration.ScheduledExecution
+{
+	public class TimeZoneStableValueOptionsProvider
+		: IStableValueOptionsProvider
+	{
+		public IEnumerable<ValueOption> GetOptions(IConfigurationRequestContext context)
+		{
+			foreach(var timezone in TimeZoneInfo.GetSystemTimeZones())
+			{
+				yield return new ValueOption()
+				{
+					Value = timezone.Id,
+					Label = timezone.DisplayName
+				};
+			}
+		}
+	}
+}

--- a/MFiles.VAF.Extensions/Configuration/ScheduledExecution/TriggerBase.cs
+++ b/MFiles.VAF.Extensions/Configuration/ScheduledExecution/TriggerBase.cs
@@ -3,7 +3,6 @@ using System;
 using System.Runtime.Serialization;
 
 namespace MFiles.VAF.Extensions.ScheduledExecution
-
 {
 	/// <summary>
 	/// Class used for configuration purposes.
@@ -69,16 +68,16 @@ namespace MFiles.VAF.Extensions.ScheduledExecution
 		}
 
 		/// <inheritdoc />
-		public override string ToString()
+		public virtual string ToString(TriggerTimeType triggerTimeType, TimeZoneInfo customTimeZone)
 		{
 			switch (this.Type)
 			{
 				case ScheduleTriggerType.Daily:
-					return this.DailyTriggerConfiguration?.ToString();
+					return this.DailyTriggerConfiguration?.ToString(triggerTimeType, customTimeZone);
 				case ScheduleTriggerType.Weekly:
-					return this.WeeklyTriggerConfiguration?.ToString();
+					return this.WeeklyTriggerConfiguration?.ToString(triggerTimeType, customTimeZone);
 				case ScheduleTriggerType.Monthly:
-					return this.DayOfMonthTriggerConfiguration?.ToString();
+					return this.DayOfMonthTriggerConfiguration?.ToString(triggerTimeType, customTimeZone);
 				default:
 					return null;
 			}

--- a/MFiles.VAF.Extensions/Configuration/ScheduledExecution/TriggerBase.cs
+++ b/MFiles.VAF.Extensions/Configuration/ScheduledExecution/TriggerBase.cs
@@ -53,16 +53,16 @@ namespace MFiles.VAF.Extensions.ScheduledExecution
 			= new DayOfMonthTrigger();
 
 		/// <inheritdoc />
-		public override DateTime? GetNextExecution(DateTime? after = null)
+		public override DateTimeOffset? GetNextExecution(DateTime? after = null, TimeZoneInfo timeZoneInfo = null)
 		{
 			switch (this.Type)
 			{
 				case ScheduleTriggerType.Daily:
-					return this.DailyTriggerConfiguration?.GetNextExecution(after);
+					return this.DailyTriggerConfiguration?.GetNextExecution(after, timeZoneInfo);
 				case ScheduleTriggerType.Weekly:
-					return this.WeeklyTriggerConfiguration?.GetNextExecution(after);
+					return this.WeeklyTriggerConfiguration?.GetNextExecution(after, timeZoneInfo);
 				case ScheduleTriggerType.Monthly:
-					return this.DayOfMonthTriggerConfiguration?.GetNextExecution(after);
+					return this.DayOfMonthTriggerConfiguration?.GetNextExecution(after, timeZoneInfo);
 				default:
 					return null;
 			}
@@ -135,7 +135,8 @@ namespace MFiles.VAF.Extensions.ScheduledExecution
 		/// Gets the next execution datetime for this trigger.
 		/// </summary>
 		/// <param name="after">The time after which the schedule should run.  Defaults to now (i.e. next-run time) if not provided.</param>
+		/// <param name="timeZoneInfo">The time zone which any triggers should be assumed to be in.</param>
 		/// <returns>The next execution time.</returns>
-		public abstract DateTime? GetNextExecution(DateTime? after = null);
+		public abstract DateTimeOffset? GetNextExecution(DateTime? after = null, TimeZoneInfo timeZoneInfo = null);
 	}
 }

--- a/MFiles.VAF.Extensions/Configuration/ScheduledExecution/TriggerTimeType.cs
+++ b/MFiles.VAF.Extensions/Configuration/ScheduledExecution/TriggerTimeType.cs
@@ -1,9 +1,16 @@
-﻿namespace MFiles.VAF.Extensions.ScheduledExecution
+﻿using MFiles.VAF.Configuration;
+
+namespace MFiles.VAF.Extensions.ScheduledExecution
 {
 	public enum TriggerTimeType
 	{
+		[JsonConfEditor(Label = ResourceMarker.Id + nameof(Resources.Configuration.TriggerTimeType_ServerTime))]
 		ServerTime = 0,
+
+		[JsonConfEditor(Label = ResourceMarker.Id + nameof(Resources.Configuration.TriggerTimeType_Utc))]
 		Utc = 1,
+
+		[JsonConfEditor(Label = ResourceMarker.Id + nameof(Resources.Configuration.TriggerTimeType_Custom))]
 		Custom = 2
 	}
 }

--- a/MFiles.VAF.Extensions/Configuration/ScheduledExecution/TriggerTimeType.cs
+++ b/MFiles.VAF.Extensions/Configuration/ScheduledExecution/TriggerTimeType.cs
@@ -3,7 +3,6 @@
 	public enum TriggerTimeType
 	{
 		ServerTime = 0,
-		Default = ServerTime,
 		Utc = 1,
 		Custom = 2
 	}

--- a/MFiles.VAF.Extensions/Configuration/ScheduledExecution/TriggerTimeType.cs
+++ b/MFiles.VAF.Extensions/Configuration/ScheduledExecution/TriggerTimeType.cs
@@ -1,0 +1,10 @@
+﻿namespace MFiles.VAF.Extensions.ScheduledExecution
+{
+	public enum TriggerTimeType
+	{
+		ServerTime = 0,
+		Default = ServerTime,
+		Utc = 1,
+		Custom = 2
+	}
+}

--- a/MFiles.VAF.Extensions/Configuration/ScheduledExecution/WeeklyTrigger.cs
+++ b/MFiles.VAF.Extensions/Configuration/ScheduledExecution/WeeklyTrigger.cs
@@ -90,7 +90,7 @@ namespace MFiles.VAF.Extensions.ScheduledExecution
 		}
 
 		/// <inheritdoc />
-		public override string ToString()
+		public override string ToString(TriggerTimeType triggerTimeType, TimeZoneInfo customTimeZone)
 		{
 			// Sanity.
 			if (null == this.TriggerDays || this.TriggerDays.Count == 0)
@@ -98,10 +98,19 @@ namespace MFiles.VAF.Extensions.ScheduledExecution
 			if (null == this.TriggerTimes || this.TriggerTimes.Count == 0)
 				return null;
 
+			// Append the time zone if we can.
+			var times = string.Join(", ", this.TriggerTimes.OrderBy(t => t).Select(t => t.ToString()));
+			if (customTimeZone != null)
+				if (customTimeZone == TimeZoneInfo.Local)
+					times += " (server time)";
+				else if (customTimeZone == TimeZoneInfo.Utc)
+					times += " (UTC)";
+				else
+					times += $" ({customTimeZone.DisplayName})";
 			return Resources.Schedule.Triggers_WeeklyTrigger.EscapeXmlForDashboard
 				(
 					string.Join(", ", this.TriggerDays.OrderBy(t => t)),
-					string.Join(", ", this.TriggerTimes.OrderBy(t => t).Select(t => t.ToString()))
+					times
 				);
 		}
 	}

--- a/MFiles.VAF.Extensions/Configuration/ScheduledExecution/WeeklyTrigger.cs
+++ b/MFiles.VAF.Extensions/Configuration/ScheduledExecution/WeeklyTrigger.cs
@@ -36,7 +36,7 @@ namespace MFiles.VAF.Extensions.ScheduledExecution
 		}
 
 		/// <inheritdoc />
-		public override DateTime? GetNextExecution(DateTime? after = null)
+		public override DateTimeOffset? GetNextExecution(DateTime? after = null, TimeZoneInfo timeZoneInfo = null)
 		{
 			// Sanity.
 			if (
@@ -47,7 +47,10 @@ namespace MFiles.VAF.Extensions.ScheduledExecution
 				return null;
 
 			// When should we start looking?
-			after = (after ?? DateTime.UtcNow).ToLocalTime();
+			after = (after ?? DateTime.UtcNow).ToUniversalTime();
+
+			// Convert the time into the timezone we're after.
+			after = TimeZoneInfo.ConvertTime(after.Value, timeZoneInfo ?? TimeZoneInfo.Local);
 
 			// Get the next execution time (this will not find run times today).
 			return this.TriggerDays
@@ -55,6 +58,7 @@ namespace MFiles.VAF.Extensions.ScheduledExecution
 				.SelectMany(d => this.TriggerTimes.Select(t => d.Add(t)))
 				.Where(d => d > after.Value)
 				.OrderBy(d => d)
+				.Select(d => d.ToUniversalTime())
 				.FirstOrDefault();
 		}
 

--- a/MFiles.VAF.Extensions/Configuration/TimeSpanEx.cs
+++ b/MFiles.VAF.Extensions/Configuration/TimeSpanEx.cs
@@ -29,7 +29,7 @@ namespace MFiles.VAF.Extensions
 		)]
 		public bool? RunOnVaultStartup { get; set; } = true;
 
-		public DateTime? GetNextExecution(DateTime? after = null)
+		public DateTimeOffset? GetNextExecution(DateTime? after = null)
 		{
 			return (after?.ToUniversalTime() ?? DateTime.UtcNow).Add(this.Interval);
 		}

--- a/MFiles.VAF.Extensions/ExtensionMethods/FormattingExtensionMethods.cs
+++ b/MFiles.VAF.Extensions/ExtensionMethods/FormattingExtensionMethods.cs
@@ -121,9 +121,9 @@ namespace MFiles.VAF.Extensions
 		/// <param name="value">The value to represent.</param>
 		/// <param name="representation">Whether the value is supposed to be last-run (past) or next-run (future).</param>
 		/// <returns>A string in English stating when it should run.</returns>
-		public static string ToTimeOffset(this DateTime value, DateTimeRepresentationOf representation)
+		public static string ToTimeOffset(this DateTime value, DateTimeRepresentationOf representation, TimeZoneInfo timeZoneInfo = null)
 		{
-			return ((DateTime?)value).ToTimeOffset(representation);
+			return ((DateTime?)value).ToTimeOffset(representation, timeZoneInfo);
 		}
 
 		/// <summary>
@@ -134,7 +134,7 @@ namespace MFiles.VAF.Extensions
 		/// <param name="value">The value to represent.</param>
 		/// <param name="representation">Whether the value is supposed to be last-run (past) or next-run (future).</param>
 		/// <returns>A string in English stating when it should run.</returns>
-		public static string ToTimeOffset(this DateTime? value, DateTimeRepresentationOf representation)
+		public static string ToTimeOffset(this DateTime? value, DateTimeRepresentationOf representation, TimeZoneInfo timeZoneInfo = null)
 		{
 			// No value?
 			if (null == value)
@@ -142,9 +142,12 @@ namespace MFiles.VAF.Extensions
 					? Resources.Time.NotRunSinceLastVaultStart.EscapeXmlForDashboard()
 					: Resources.Time.NotScheduled.EscapeXmlForDashboard();
 
+			// Ensure we have a timezone.
+			timeZoneInfo = timeZoneInfo ?? TimeZoneInfo.Local;
+
 			// Find the difference between the scheduled time and now.
 			var universalValue = value.Value.ToUniversalTime();
-			var localTime = universalValue.ToLocalTime();
+			var localTime = TimeZoneInfo.ConvertTimeFromUtc(universalValue, timeZoneInfo); // universalValue.ToLocalTime();
 			var diff = universalValue.Subtract(DateTime.UtcNow);
 			var isInPast = diff < TimeSpan.Zero;
 			if (Math.Abs(diff.TotalSeconds) <= 10)

--- a/MFiles.VAF.Extensions/RecurringOperationConfigurationManager.cs
+++ b/MFiles.VAF.Extensions/RecurringOperationConfigurationManager.cs
@@ -53,7 +53,7 @@ namespace MFiles.VAF.Extensions
 		/// <param name="queueId">The queue ID</param>
 		/// <param name="taskType">The task type ID</param>
 		/// <returns>The datetime it should run, or null if not available.</returns>
-		public DateTime? GetNextTaskProcessorExecution(string queueId, string taskType, DateTime? after = null)
+		public DateTimeOffset? GetNextTaskProcessorExecution(string queueId, string taskType, DateTime? after = null)
 		{
 			return this.TryGetValue(queueId, taskType, out IRecurrenceConfiguration recurringOperation)
 				? recurringOperation.GetNextExecution(after)
@@ -170,7 +170,7 @@ namespace MFiles.VAF.Extensions
 				}
 
 				// If we don't have a schedule then stop.
-				nextExecution = nextExecution ?? schedule?.GetNextExecution();
+				nextExecution = nextExecution ?? schedule?.GetNextExecution()?.UtcDateTime;
 				if (false == nextExecution.HasValue)
 				{
 					this.Logger?.Debug($"Processor for queue {tuple.Item1.QueueID} of type {tuple.Item1.TaskType} has no next-execution returned.  It will not be scheduled to run.");

--- a/MFiles.VAF.Extensions/Resources/Configuration.Designer.cs
+++ b/MFiles.VAF.Extensions/Resources/Configuration.Designer.cs
@@ -250,6 +250,42 @@ namespace MFiles.VAF.Extensions.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to .
+        /// </summary>
+        internal static string Schedule_TriggerTimeCustomTimeZone_HelpText {
+            get {
+                return ResourceManager.GetString("Schedule_TriggerTimeCustomTimeZone_HelpText", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Custom Time Zone.
+        /// </summary>
+        internal static string Schedule_TriggerTimeCustomTimeZone_Label {
+            get {
+                return ResourceManager.GetString("Schedule_TriggerTimeCustomTimeZone_Label", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Triggers are defined as a time (e.g. 5am); choose here whether this time refers to the time on the server, the time in UTC, or the time in a specified timezone..
+        /// </summary>
+        internal static string Schedule_TriggerTimeType_HelpText {
+            get {
+                return ResourceManager.GetString("Schedule_TriggerTimeType_HelpText", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Trigger Time Type.
+        /// </summary>
+        internal static string Schedule_TriggerTimeType_Label {
+            get {
+                return ResourceManager.GetString("Schedule_TriggerTimeType_Label", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Use closest representable last day of month.
         /// </summary>
         internal static string Schedule_UnrepresentableDateHandling_LastDayOfMonth {
@@ -336,6 +372,33 @@ namespace MFiles.VAF.Extensions.Resources {
         internal static string TimeSpanEx_Interval {
             get {
                 return ResourceManager.GetString("TimeSpanEx_Interval", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The trigger times should be interpreted as whatever custom time zone is configured..
+        /// </summary>
+        internal static string TriggerTimeType_Custom {
+            get {
+                return ResourceManager.GetString("TriggerTimeType_Custom", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The trigger times should be interpreted in whatever time zone the server is configured in.  This is the default..
+        /// </summary>
+        internal static string TriggerTimeType_ServerTime {
+            get {
+                return ResourceManager.GetString("TriggerTimeType_ServerTime", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The trigger times should be interpreted as UTC..
+        /// </summary>
+        internal static string TriggerTimeType_Utc {
+            get {
+                return ResourceManager.GetString("TriggerTimeType_Utc", resourceCulture);
             }
         }
     }

--- a/MFiles.VAF.Extensions/Resources/Configuration.Designer.cs
+++ b/MFiles.VAF.Extensions/Resources/Configuration.Designer.cs
@@ -376,7 +376,7 @@ namespace MFiles.VAF.Extensions.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The trigger times should be interpreted as whatever custom time zone is configured..
+        ///   Looks up a localized string similar to Custom.
         /// </summary>
         internal static string TriggerTimeType_Custom {
             get {
@@ -385,7 +385,7 @@ namespace MFiles.VAF.Extensions.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The trigger times should be interpreted in whatever time zone the server is configured in.  This is the default..
+        ///   Looks up a localized string similar to The server time zone.
         /// </summary>
         internal static string TriggerTimeType_ServerTime {
             get {
@@ -394,7 +394,7 @@ namespace MFiles.VAF.Extensions.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The trigger times should be interpreted as UTC..
+        ///   Looks up a localized string similar to Co-ordinated Universal Time (UTC).
         /// </summary>
         internal static string TriggerTimeType_Utc {
             get {

--- a/MFiles.VAF.Extensions/Resources/Configuration.resx
+++ b/MFiles.VAF.Extensions/Resources/Configuration.resx
@@ -223,12 +223,12 @@
     <value>Interval</value>
   </data>
   <data name="TriggerTimeType_Custom" xml:space="preserve">
-    <value>The trigger times should be interpreted as whatever custom time zone is configured.</value>
+    <value>Custom</value>
   </data>
   <data name="TriggerTimeType_ServerTime" xml:space="preserve">
-    <value>The trigger times should be interpreted in whatever time zone the server is configured in.  This is the default.</value>
+    <value>The server time zone</value>
   </data>
   <data name="TriggerTimeType_Utc" xml:space="preserve">
-    <value>The trigger times should be interpreted as UTC.</value>
+    <value>Co-ordinated Universal Time (UTC)</value>
   </data>
 </root>

--- a/MFiles.VAF.Extensions/Resources/Configuration.resx
+++ b/MFiles.VAF.Extensions/Resources/Configuration.resx
@@ -192,6 +192,18 @@
   <data name="Schedule_Triggers_Label" xml:space="preserve">
     <value>Triggers</value>
   </data>
+  <data name="Schedule_TriggerTimeCustomTimeZone_HelpText" xml:space="preserve">
+    <value />
+  </data>
+  <data name="Schedule_TriggerTimeCustomTimeZone_Label" xml:space="preserve">
+    <value>Custom Time Zone</value>
+  </data>
+  <data name="Schedule_TriggerTimeType_HelpText" xml:space="preserve">
+    <value>Triggers are defined as a time (e.g. 5am); choose here whether this time refers to the time on the server, the time in UTC, or the time in a specified timezone.</value>
+  </data>
+  <data name="Schedule_TriggerTimeType_Label" xml:space="preserve">
+    <value>Trigger Time Type</value>
+  </data>
   <data name="Schedule_UnrepresentableDateHandling_LastDayOfMonth" xml:space="preserve">
     <value>Use closest representable last day of month</value>
   </data>
@@ -209,5 +221,14 @@
   </data>
   <data name="TimeSpanEx_Interval" xml:space="preserve">
     <value>Interval</value>
+  </data>
+  <data name="TriggerTimeType_Custom" xml:space="preserve">
+    <value>The trigger times should be interpreted as whatever custom time zone is configured.</value>
+  </data>
+  <data name="TriggerTimeType_ServerTime" xml:space="preserve">
+    <value>The trigger times should be interpreted in whatever time zone the server is configured in.  This is the default.</value>
+  </data>
+  <data name="TriggerTimeType_Utc" xml:space="preserve">
+    <value>The trigger times should be interpreted as UTC.</value>
   </data>
 </root>

--- a/MFiles.VAF.Extensions/Resources/Dashboard.Designer.cs
+++ b/MFiles.VAF.Extensions/Resources/Dashboard.Designer.cs
@@ -115,7 +115,7 @@ namespace MFiles.VAF.Extensions.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Completed. Started at approximately {0} server time (took {1})..
+        ///   Looks up a localized string similar to Completed. Started at approximately {0} (took {1})..
         /// </summary>
         internal static string AsynchronousOperations_Table_CompletedRowTitle_WithTimes {
             get {
@@ -151,7 +151,7 @@ namespace MFiles.VAF.Extensions.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Failed. Started at approximately {0} server time (took {1})..
+        ///   Looks up a localized string similar to Failed. Started at approximately {0} (took {1})..
         /// </summary>
         internal static string AsynchronousOperations_Table_FailedRowTitle_WithTimes {
             get {
@@ -214,7 +214,7 @@ namespace MFiles.VAF.Extensions.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Running. Started at approximately {0} server time (taken {1} so far)..
+        ///   Looks up a localized string similar to Running. Started at approximately {0} (taken {1} so far)..
         /// </summary>
         internal static string AsynchronousOperations_Table_RunningRowTitle_WithTimes {
             get {

--- a/MFiles.VAF.Extensions/Resources/Dashboard.resx
+++ b/MFiles.VAF.Extensions/Resources/Dashboard.resx
@@ -140,7 +140,7 @@
     <value>Completed.</value>
   </data>
   <data name="AsynchronousOperations_Table_CompletedRowTitle_WithTimes" xml:space="preserve">
-    <value>Completed. Started at approximately {0} server time (took {1}).</value>
+    <value>Completed. Started at approximately {0} (took {1}).</value>
     <comment>{0} will be replaced with started time in yyyy-MM-dd HH:mm:ss format. {1} will be replaced with the duration.</comment>
   </data>
   <data name="AsynchronousOperations_Table_DetailsHeader" xml:space="preserve">
@@ -153,7 +153,7 @@
     <value>Failed.</value>
   </data>
   <data name="AsynchronousOperations_Table_FailedRowTitle_WithTimes" xml:space="preserve">
-    <value>Failed. Started at approximately {0} server time (took {1}).</value>
+    <value>Failed. Started at approximately {0} (took {1}).</value>
     <comment>{0} will be replaced with started time in yyyy-MM-dd HH:mm:ss format. {1} will be replaced with the duration.</comment>
   </data>
   <data name="AsynchronousOperations_Table_FilteredListComment" xml:space="preserve">
@@ -180,7 +180,7 @@
     <value>Running.</value>
   </data>
   <data name="AsynchronousOperations_Table_RunningRowTitle_WithTimes" xml:space="preserve">
-    <value>Running. Started at approximately {0} server time (taken {1} so far).</value>
+    <value>Running. Started at approximately {0} (taken {1} so far).</value>
     <comment>{0} will be replaced with started time in yyyy-MM-dd HH:mm:ss format. {1} will be replaced with the duration.</comment>
   </data>
   <data name="AsynchronousOperations_Table_ScheduledHeader" xml:space="preserve">

--- a/MFiles.VAF.Extensions/Resources/Time.Designer.cs
+++ b/MFiles.VAF.Extensions/Resources/Time.Designer.cs
@@ -61,7 +61,7 @@ namespace MFiles.VAF.Extensions.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to At {0} server time..
+        ///   Looks up a localized string similar to At {0}..
         /// </summary>
         internal static string AtSpecificTime {
             get {
@@ -70,7 +70,7 @@ namespace MFiles.VAF.Extensions.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to At {0} server time on {1}..
+        ///   Looks up a localized string similar to At {0} on {1}..
         /// </summary>
         internal static string AtSpecificTimeOnDate {
             get {
@@ -79,7 +79,7 @@ namespace MFiles.VAF.Extensions.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to At {0} server time on {1} (in {2})..
+        ///   Looks up a localized string similar to At {0} on {1} (in {2})..
         /// </summary>
         internal static string AtSpecificTimeOnDateWithDifference {
             get {
@@ -88,7 +88,7 @@ namespace MFiles.VAF.Extensions.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to At {0} server time (in {1})..
+        ///   Looks up a localized string similar to At {0} (in {1})..
         /// </summary>
         internal static string AtSpecificTimeWithDifference {
             get {

--- a/MFiles.VAF.Extensions/Resources/Time.resx
+++ b/MFiles.VAF.Extensions/Resources/Time.resx
@@ -118,19 +118,19 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="AtSpecificTime" xml:space="preserve">
-    <value>At {0} server time.</value>
+    <value>At {0}.</value>
     <comment>{0} will be replaced with the scheduled time in 24-hour format.</comment>
   </data>
   <data name="AtSpecificTimeOnDate" xml:space="preserve">
-    <value>At {0} server time on {1}.</value>
+    <value>At {0} on {1}.</value>
     <comment>{0} will be replaced with the scheduled time in 24-hour format.  {1} will be replaced with the scheduled date in ISO 8601 format (yyyy-MM-dd).</comment>
   </data>
   <data name="AtSpecificTimeOnDateWithDifference" xml:space="preserve">
-    <value>At {0} server time on {1} (in {2}).</value>
+    <value>At {0} on {1} (in {2}).</value>
     <comment>{0} will be replaced with the scheduled time in 24-hour format.  {1} will be replaced with the scheduled date in ISO 8601 format (yyyy-MM-dd).  {2} will be replaced with the time until the next-run time.</comment>
   </data>
   <data name="AtSpecificTimeWithDifference" xml:space="preserve">
-    <value>At {0} server time (in {1}).</value>
+    <value>At {0} (in {1}).</value>
     <comment>{0} will be replaced with the scheduled time in 24-hour format.  {1} will be replaced with the time until the next-run time.</comment>
   </data>
   <data name="Component_Day" xml:space="preserve">

--- a/MFiles.VAF.Extensions/TaskManagerEx.GetDashboardContent.cs
+++ b/MFiles.VAF.Extensions/TaskManagerEx.GetDashboardContent.cs
@@ -134,7 +134,7 @@ namespace MFiles.VAF.Extensions
 					}
 
 					// Does it have any configuration instructions?
-						IRecurrenceConfiguration recurrenceConfiguration = null;
+					IRecurrenceConfiguration recurrenceConfiguration = null;
 					if (this
 						.VaultApplication?
 						.RecurringOperationConfigurationManager?
@@ -191,7 +191,7 @@ namespace MFiles.VAF.Extensions
 					(
 						htmlString
 						+ executions?
-							.AsDashboardContent()?
+							.AsDashboardContent(recurrenceConfiguration)?
 							.ToXmlString()
 					);
 

--- a/MFiles.VAF.Extensions/TaskManagerEx.cs
+++ b/MFiles.VAF.Extensions/TaskManagerEx.cs
@@ -210,7 +210,7 @@ namespace MFiles.VAF.Extensions
 
 								// Schedule.
 								this.Logger?.Info($"Re-scheduling {t.TaskType} on {t.QueueID} for {nextExecutionDate.Value}");
-								this.RescheduleTask(t.QueueID, t.TaskType, vault: this.Vault, scheduleFor: nextExecutionDate);
+								this.RescheduleTask(t.QueueID, t.TaskType, vault: this.Vault, scheduleFor: nextExecutionDate?.UtcDateTime);
 							}
 							break;
 					}

--- a/MFiles.VAF.Extensions/TaskQueueBackgroundOperations/TaskQueueBackgroundOperation.cs
+++ b/MFiles.VAF.Extensions/TaskQueueBackgroundOperations/TaskQueueBackgroundOperation.cs
@@ -338,7 +338,7 @@ namespace MFiles.VAF.Extensions
 			// Run (which will set up the next iteration).
 			var nextRun = this.Schedule?.GetNextExecution();
 			if(nextRun.HasValue)
-				this.RunOnce(runAt: nextRun.Value, directive: directive);
+				this.RunOnce(runAt: nextRun.Value.UtcDateTime, directive: directive);
 		}
 
 		/// <summary>

--- a/MFiles.VAF.Extensions/TaskQueueBackgroundOperations/TaskQueueBackgroundOperationManager/TaskQueueBackgroundOperationManager.cs
+++ b/MFiles.VAF.Extensions/TaskQueueBackgroundOperations/TaskQueueBackgroundOperationManager/TaskQueueBackgroundOperationManager.cs
@@ -262,7 +262,7 @@ namespace MFiles.VAF.Extensions
 				case TaskQueueBackgroundOperationRepeatType.Schedule:
 
 					// Get the next execution time from the schedule.
-					nextRun = bo.Schedule?.GetNextExecution(DateTime.Now);
+					nextRun = bo.Schedule?.GetNextExecution(DateTime.Now)?.UtcDateTime;
 					break;
 			}
 


### PR DESCRIPTION
In the current release all times are deemed to be "server time", and executed according to whatever timezone the server is in.  Where servers may be in different timezones to users (e.g. cloud environments, or users across multiple timezones) this can introduce complexity and potential for misconfiguration.

In this release times can be marked as "server time" (default), "UTC", or marked as in a specific timezone.

Note: tasks are still scheduled in UTC as that is required, but the timezone is used to calculate the correct offset.  Some unit tests also consider summer time offsets.