### PR TITLE
CI changes (remove need for prerelease branch):

### DIFF
--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -2,7 +2,7 @@ name: Build and publish
 
 on:
   push:
-    branches: [ prerelease, release ]
+    branches: [ release ]
     
 jobs:
   build:
@@ -14,27 +14,11 @@ jobs:
       with:
         fetch-depth: 0
 
-    - name: versionSuffix
-      shell: pwsh
-      run: |
-        If([string]::IsNullOrEmpty('${{ github.event.inputs.versionSuffix }}'))
-        {
-            If('${{ github.ref_name }}' -eq 'release')
-            {
-                $versionSuffix = ''
-            }else{
-                $versionSuffix = '-' + ('${{ github.ref_name }}' -replace '[^a-zA-Z0-9]','-')
-            }
-        }else{
-            $versionSuffix = '-' + ('${{ github.event.inputs.versionSuffix }}' -replace '[^a-zA-Z0-9]','-')
-        }
-        echo "versionSuffix=$versionSuffix" | Out-File -FilePath $Env:GITHUB_ENV -Append
-
     - name: Get version number
       shell: pwsh
       run: |
         $versionNumber = Get-Date -Format "yy.M.${{ github.run_number }}"
-        echo "versionNumber=$versionNumber${{ env.versionSuffix }}" | Out-File -FilePath $Env:GITHUB_ENV -Encoding utf-8 -Append
+        echo "versionNumber=$versionNumber" | Out-File -FilePath $Env:GITHUB_ENV -Encoding utf-8 -Append
 
     - name: Write release notes
       shell: pwsh

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,9 +2,9 @@ name: Build
 
 on:
   push:
-    branches: [ master, main ]
-#  pull_request:
-#    branches: [ master, main ]
+    branches: [ master, main ] # Build on main/master branch
+  pull_request:
+    branches: [ master, main ] # Build on PR/MR that target main/master
 
 jobs:
   build:

--- a/.github/workflows/manual.yml
+++ b/.github/workflows/manual.yml
@@ -28,7 +28,12 @@ jobs:
             {
                 $versionSuffix = ''
             }else{
-                $versionSuffix = '-' + ('${{ github.ref_name }}' -replace '[^a-zA-Z0-9]','-')
+                If('${{ github.ref_name }}' -eq '' || '${{ github.ref_name }}' -eq 'master' || '${{ github.ref_name }}' -eq 'main')
+                {
+                    $versionSuffix = '-prerelease'
+                }else{
+                    $versionSuffix = '-' + ('${{ github.ref_name }}' -replace '[^a-zA-Z0-9]','-')
+                }
             }
         }else{
             $versionSuffix = '-' + ('${{ github.event.inputs.versionSuffix }}' -replace '[^a-zA-Z0-9]','-')


### PR DESCRIPTION
Build now runs on PR/MR targeting main/master.
Build-and-publish now only runs on release.
Manual build can be run against master to default to "-prerelease" suffix.