### PR TITLE
Fix for issue 83

### DIFF
--- a/MFiles.VAF.Extensions.Tests/Configuration/FrequencyTests.cs
+++ b/MFiles.VAF.Extensions.Tests/Configuration/FrequencyTests.cs
@@ -87,7 +87,7 @@ namespace MFiles.VAF.Extensions.Tests.Configuration
 			DateTimeOffset expected
 		)
 		{
-			var frequency = JsonConvert.DeserializeObject<Frequency>(@"{
+			var frequency = Newtonsoft.Json.JsonConvert.DeserializeObject<Frequency>(@"{
     ""Triggers"": [
         {
             ""Type"": ""Daily"",
@@ -113,7 +113,7 @@ namespace MFiles.VAF.Extensions.Tests.Configuration
 		[TestMethod]
 		public void SplitTriggerType(DateTime now, DateTime expected)
 		{
-			var frequency = JsonConvert.DeserializeObject<Frequency>(@"{
+			var frequency = Newtonsoft.Json.JsonConvert.DeserializeObject<Frequency>(@"{
     ""Triggers"": [
         {
             ""Type"": ""Weekly"",
@@ -229,9 +229,9 @@ namespace MFiles.VAF.Extensions.Tests.Configuration
 				RecurrenceType = RecurrenceType.Interval
 			};
 			var expected = JToken.Parse("{\"RecurrenceType\":1,\"Interval\":{\r\n  \"Hours\" : 1, \"Minutes\" : 2, \"Seconds\" : 3 , \"RunOnVaultStartup\": true\r\n} }");
-			var output = JToken.Parse(JsonConvert.SerializeObject(frequency));
+			var output = JToken.Parse(Newtonsoft.Json.JsonConvert.SerializeObject(frequency));
 
-			Assert.AreEqual(JsonConvert.SerializeObject(expected), JsonConvert.SerializeObject(output));
+			Assert.AreEqual(Newtonsoft.Json.JsonConvert.SerializeObject(expected), Newtonsoft.Json.JsonConvert.SerializeObject(output));
 		}
 
 		/// <summary>
@@ -260,9 +260,9 @@ namespace MFiles.VAF.Extensions.Tests.Configuration
 				RecurrenceType = RecurrenceType.Schedule
 			};
 			var expected = JToken.Parse("{\"RecurrenceType\":2,\"Schedule\":{\"Enabled\":true,\"Triggers\":[{\"Type\":1,\"DailyTriggerConfiguration\":{\"TriggerTimes\":[\"02:03:04\"]},\"WeeklyTriggerConfiguration\":{\"TriggerDays\":[],\"TriggerTimes\":[]},\"DayOfMonthTriggerConfiguration\":{\"UnrepresentableDateHandling\":0,\"TriggerDays\":[],\"TriggerTimes\":[]}}],\"RunOnVaultStartup\":false}}");
-			var output = JToken.Parse(JsonConvert.SerializeObject(frequency));
+			var output = JToken.Parse(Newtonsoft.Json.JsonConvert.SerializeObject(frequency));
 
-			Assert.AreEqual(JsonConvert.SerializeObject(expected), JsonConvert.SerializeObject(output));
+			Assert.AreEqual(Newtonsoft.Json.JsonConvert.SerializeObject(expected), Newtonsoft.Json.JsonConvert.SerializeObject(output));
 		}
 
 		/// <summary>
@@ -272,7 +272,7 @@ namespace MFiles.VAF.Extensions.Tests.Configuration
 		public void DeserializesCorrectly()
 		{
 			string json = @"{""RecurrenceType"":1,""Interval"":{ ""Interval"": ""01:02:03"",  ""RunOnVaultStartup"": true}}";
-			Frequency output = JsonConvert.DeserializeObject<Frequency>(json);
+			Frequency output = Newtonsoft.Json.JsonConvert.DeserializeObject<Frequency>(json);
 
 			Frequency expected = new Frequency()
 			{
@@ -280,7 +280,7 @@ namespace MFiles.VAF.Extensions.Tests.Configuration
 				RecurrenceType = RecurrenceType.Interval
 			};
 
-			Assert.AreEqual(JsonConvert.SerializeObject(expected), JsonConvert.SerializeObject(output));
+			Assert.AreEqual(Newtonsoft.Json.JsonConvert.SerializeObject(expected), Newtonsoft.Json.JsonConvert.SerializeObject(output));
 		}
 
 		/// <summary>
@@ -290,7 +290,7 @@ namespace MFiles.VAF.Extensions.Tests.Configuration
 		public void DeserializesTimeSpanExCorrectly_WithoutRunOnVaultStartup()
 		{
 			string json = @"{ ""Interval"": ""01:02:03""}";
-			Frequency output = JsonConvert.DeserializeObject<Frequency>(json);
+			Frequency output = Newtonsoft.Json.JsonConvert.DeserializeObject<Frequency>(json);
 
 			Frequency expected = new Frequency()
 			{
@@ -301,7 +301,7 @@ namespace MFiles.VAF.Extensions.Tests.Configuration
 				RecurrenceType = RecurrenceType.Interval
 			};
 
-			Assert.AreEqual(JsonConvert.SerializeObject(expected), JsonConvert.SerializeObject(output));
+			Assert.AreEqual(Newtonsoft.Json.JsonConvert.SerializeObject(expected), Newtonsoft.Json.JsonConvert.SerializeObject(output));
 		}
 
 		/// <summary>
@@ -311,7 +311,7 @@ namespace MFiles.VAF.Extensions.Tests.Configuration
 		public void DeserializesTimeSpanExCorrectly_RunOnVaultStartupEqualsFalse()
 		{
 			string json = @"{ ""Interval"": ""01:02:03"", ""RunOnVaultStartup"": false}";
-			Frequency output = JsonConvert.DeserializeObject<Frequency>(json);
+			Frequency output = Newtonsoft.Json.JsonConvert.DeserializeObject<Frequency>(json);
 
 			Frequency expected = new Frequency()
 			{
@@ -322,7 +322,7 @@ namespace MFiles.VAF.Extensions.Tests.Configuration
 				RecurrenceType = RecurrenceType.Interval
 			};
 
-			Assert.AreEqual(JsonConvert.SerializeObject(expected), JsonConvert.SerializeObject(output));
+			Assert.AreEqual(Newtonsoft.Json.JsonConvert.SerializeObject(expected), Newtonsoft.Json.JsonConvert.SerializeObject(output));
 		}
 
 		/// <summary>
@@ -332,7 +332,7 @@ namespace MFiles.VAF.Extensions.Tests.Configuration
 		public void DeserializesTimeSpanExCorrectly_RunOnVaultStartupEqualsTrue()
 		{
 			string json = @"{ ""Interval"": ""01:02:03"",  ""RunOnVaultStartup"": true}";
-			Frequency output = JsonConvert.DeserializeObject<Frequency>(json);
+			Frequency output = Newtonsoft.Json.JsonConvert.DeserializeObject<Frequency>(json);
 
 			Frequency expected = new Frequency()
 			{
@@ -340,7 +340,7 @@ namespace MFiles.VAF.Extensions.Tests.Configuration
 				RecurrenceType = RecurrenceType.Interval
 			};
 
-			Assert.AreEqual(JsonConvert.SerializeObject(expected), JsonConvert.SerializeObject(output));
+			Assert.AreEqual(Newtonsoft.Json.JsonConvert.SerializeObject(expected), Newtonsoft.Json.JsonConvert.SerializeObject(output));
 		}
 
 		/// <summary>
@@ -350,9 +350,9 @@ namespace MFiles.VAF.Extensions.Tests.Configuration
 		public void DeserializesTimeSpan()
 		{
 			TimeSpan timespan = new TimeSpan(1, 2, 3);
-			string json = JsonConvert.SerializeObject(timespan);
+			string json = Newtonsoft.Json.JsonConvert.SerializeObject(timespan);
 
-			var output = JsonConvert.DeserializeObject<Frequency>(json);
+			var output = Newtonsoft.Json.JsonConvert.DeserializeObject<Frequency>(json);
 
 			Frequency expected = new Frequency()
 			{
@@ -360,7 +360,7 @@ namespace MFiles.VAF.Extensions.Tests.Configuration
 				RecurrenceType = RecurrenceType.Interval
 			};
 
-			Assert.AreEqual(JsonConvert.SerializeObject(expected), JsonConvert.SerializeObject(output));
+			Assert.AreEqual(Newtonsoft.Json.JsonConvert.SerializeObject(expected), Newtonsoft.Json.JsonConvert.SerializeObject(output));
 			//output.ShouldBeEquivalentTo(expected);
 		}
 
@@ -371,7 +371,7 @@ namespace MFiles.VAF.Extensions.Tests.Configuration
 		public void DeserializesFrequencyScheduleCorrectly_Daily()
 		{
 			string json = "{\"RecurrenceType\":2,\"Schedule\":{\"Triggers\":[{\"Type\":1,\"DailyTriggerConfiguration\":{\"TriggerTimes\":[\"02:03:04\"]}}]}}";
-			Frequency output = JsonConvert.DeserializeObject<Frequency>(json);
+			Frequency output = Newtonsoft.Json.JsonConvert.DeserializeObject<Frequency>(json);
 
 			Frequency expected = new Frequency()
 			{
@@ -392,7 +392,7 @@ namespace MFiles.VAF.Extensions.Tests.Configuration
 				RecurrenceType = RecurrenceType.Schedule
 			};
 
-			Assert.AreEqual(JsonConvert.SerializeObject(expected), JsonConvert.SerializeObject(output));
+			Assert.AreEqual(Newtonsoft.Json.JsonConvert.SerializeObject(expected), Newtonsoft.Json.JsonConvert.SerializeObject(output));
 		}
 
 		/// <summary>
@@ -402,7 +402,7 @@ namespace MFiles.VAF.Extensions.Tests.Configuration
 		public void DeserializesScheduleCorrectly_Daily()
 		{
 			string json = "{\"Triggers\":[{\"Type\":1,\"DailyTriggerConfiguration\":{\"TriggerTimes\":[\"02:03:04\"]}}]}";
-			Frequency output = JsonConvert.DeserializeObject<Frequency>(json);
+			Frequency output = Newtonsoft.Json.JsonConvert.DeserializeObject<Frequency>(json);
 
 			Frequency expected = new Frequency()
 			{
@@ -423,7 +423,7 @@ namespace MFiles.VAF.Extensions.Tests.Configuration
 				RecurrenceType = RecurrenceType.Schedule
 			};
 
-			Assert.AreEqual(JsonConvert.SerializeObject(expected), JsonConvert.SerializeObject(output));
+			Assert.AreEqual(Newtonsoft.Json.JsonConvert.SerializeObject(expected), Newtonsoft.Json.JsonConvert.SerializeObject(output));
 		}
 
 		/// <summary>
@@ -451,15 +451,15 @@ namespace MFiles.VAF.Extensions.Tests.Configuration
 				RunOnVaultStartup = false //Picked false because it's not the default value
 			};
 
-			string json = JsonConvert.SerializeObject(schedule);
-			var output = JsonConvert.DeserializeObject<Frequency>(json);
+			string json = Newtonsoft.Json.JsonConvert.SerializeObject(schedule);
+			var output = Newtonsoft.Json.JsonConvert.DeserializeObject<Frequency>(json);
 			var expected = new Frequency()
 			{
 				Schedule = schedule,
 				RecurrenceType = RecurrenceType.Schedule,
 			};
 
-			Assert.AreEqual(JsonConvert.SerializeObject(expected), JsonConvert.SerializeObject(output));
+			Assert.AreEqual(Newtonsoft.Json.JsonConvert.SerializeObject(expected), Newtonsoft.Json.JsonConvert.SerializeObject(output));
 		}
 
 		/// <summary>
@@ -473,9 +473,9 @@ namespace MFiles.VAF.Extensions.Tests.Configuration
 				Frequency = new TimeSpan(1, 2, 3)
 			};
 
-			string json = JsonConvert.SerializeObject(oldWrapper);
+			string json = Newtonsoft.Json.JsonConvert.SerializeObject(oldWrapper);
 
-			var output = JsonConvert.DeserializeObject<FrequencyWrapper>(json);
+			var output = Newtonsoft.Json.JsonConvert.DeserializeObject<FrequencyWrapper>(json);
 			var expected = new FrequencyWrapper()
 			{
 				Frequency = new Frequency()
@@ -485,7 +485,7 @@ namespace MFiles.VAF.Extensions.Tests.Configuration
 				}
 			};
 
-			Assert.AreEqual(JsonConvert.SerializeObject(expected), JsonConvert.SerializeObject(output));
+			Assert.AreEqual(Newtonsoft.Json.JsonConvert.SerializeObject(expected), Newtonsoft.Json.JsonConvert.SerializeObject(output));
 		}
 
 		/// <summary>
@@ -503,9 +503,9 @@ namespace MFiles.VAF.Extensions.Tests.Configuration
 				Frequency = timeSpanEx
 			};
 
-			string json = JsonConvert.SerializeObject(oldWrapper);
+			string json = Newtonsoft.Json.JsonConvert.SerializeObject(oldWrapper);
 
-			var output = JsonConvert.DeserializeObject<FrequencyWrapper>(json);
+			var output = Newtonsoft.Json.JsonConvert.DeserializeObject<FrequencyWrapper>(json);
 			var expected = new FrequencyWrapper()
 			{
 				Frequency = new Frequency()
@@ -515,7 +515,7 @@ namespace MFiles.VAF.Extensions.Tests.Configuration
 				}
 			};
 
-			Assert.AreEqual(JsonConvert.SerializeObject(expected), JsonConvert.SerializeObject(output));
+			Assert.AreEqual(Newtonsoft.Json.JsonConvert.SerializeObject(expected), Newtonsoft.Json.JsonConvert.SerializeObject(output));
 		}
 
 		/// <summary>
@@ -547,9 +547,9 @@ namespace MFiles.VAF.Extensions.Tests.Configuration
 				Frequency = schedule
 			};
 
-			string json = JsonConvert.SerializeObject(oldWrapper);
+			string json = Newtonsoft.Json.JsonConvert.SerializeObject(oldWrapper);
 
-			var output = JsonConvert.DeserializeObject<FrequencyWrapper>(json);
+			var output = Newtonsoft.Json.JsonConvert.DeserializeObject<FrequencyWrapper>(json);
 			var expected = new FrequencyWrapper()
 			{
 				Frequency = new Frequency()
@@ -559,7 +559,7 @@ namespace MFiles.VAF.Extensions.Tests.Configuration
 				}
 			};
 
-			Assert.AreEqual(JsonConvert.SerializeObject(expected), JsonConvert.SerializeObject(output));
+			Assert.AreEqual(Newtonsoft.Json.JsonConvert.SerializeObject(expected), Newtonsoft.Json.JsonConvert.SerializeObject(output));
 		}
 	}
 }

--- a/MFiles.VAF.Extensions.Tests/Configuration/TimeSpanExTests.cs
+++ b/MFiles.VAF.Extensions.Tests/Configuration/TimeSpanExTests.cs
@@ -21,7 +21,7 @@ namespace MFiles.VAF.Extensions.Tests.Configuration
 		[TestMethod]
 		public void DeserializesTimeSpanString()
 		{
-			var output = JsonConvert.DeserializeObject<Wrapper>(@"{ ""TimeSpanEx"" : ""11:01:02"" }");
+			var output = Newtonsoft.Json.JsonConvert.DeserializeObject<Wrapper>(@"{ ""TimeSpanEx"" : ""11:01:02"" }");
 			Assert.IsNotNull(output?.TimeSpanEx);
 			Assert.AreEqual(new TimeSpan(11, 01, 02), output.TimeSpanEx.GetInterval());
 		}
@@ -29,7 +29,7 @@ namespace MFiles.VAF.Extensions.Tests.Configuration
 		[TestMethod]
 		public void DeserializesTimeSpanExString()
 		{
-			var output = JsonConvert.DeserializeObject<Wrapper>(@"{ ""TimeSpanEx"" : { ""Interval"" : ""01:02:03"" } }");
+			var output = Newtonsoft.Json.JsonConvert.DeserializeObject<Wrapper>(@"{ ""TimeSpanEx"" : { ""Interval"" : ""01:02:03"" } }");
 			Assert.IsNotNull(output?.TimeSpanEx);
 			Assert.AreEqual(new TimeSpan(01, 02, 03), output.TimeSpanEx.GetInterval());
 		}
@@ -37,7 +37,7 @@ namespace MFiles.VAF.Extensions.Tests.Configuration
 		[TestMethod]
 		public void DeserializesTimeSpanExWithRunOnVaultStartup_True()
 		{
-			var output = JsonConvert.DeserializeObject<Wrapper>(@"{ ""TimeSpanEx"" : { ""Interval"" : ""01:02:03"", ""RunOnVaultStartup"" : true } }");
+			var output = Newtonsoft.Json.JsonConvert.DeserializeObject<Wrapper>(@"{ ""TimeSpanEx"" : { ""Interval"" : ""01:02:03"", ""RunOnVaultStartup"" : true } }");
 			Assert.IsNotNull(output?.TimeSpanEx);
 			Assert.IsTrue(output.TimeSpanEx.RunOnVaultStartup.HasValue);
 			Assert.IsTrue(output.TimeSpanEx.RunOnVaultStartup.Value);
@@ -46,7 +46,7 @@ namespace MFiles.VAF.Extensions.Tests.Configuration
 		[TestMethod]
 		public void DeserializesTimeSpanExWithRunOnVaultStartup_False()
 		{
-			var output = JsonConvert.DeserializeObject<Wrapper>(@"{ ""TimeSpanEx"" : { ""Interval"" : ""01:02:03"", ""RunOnVaultStartup"" : false } }");
+			var output = Newtonsoft.Json.JsonConvert.DeserializeObject<Wrapper>(@"{ ""TimeSpanEx"" : { ""Interval"" : ""01:02:03"", ""RunOnVaultStartup"" : false } }");
 			Assert.IsNotNull(output?.TimeSpanEx);
 			Assert.IsTrue(output.TimeSpanEx.RunOnVaultStartup.HasValue);
 			Assert.IsFalse(output.TimeSpanEx.RunOnVaultStartup.Value);
@@ -55,7 +55,7 @@ namespace MFiles.VAF.Extensions.Tests.Configuration
 		[TestMethod]
 		public void DeserializesSeparateIntervalMembersString()
 		{
-			var output = JsonConvert.DeserializeObject<Wrapper>(@"{ ""TimeSpanEx"" : { ""Hours"" : 1, ""Minutes"" : 2, ""Seconds"" : 3, ""RunOnVaultStartup"" : false } }");
+			var output = Newtonsoft.Json.JsonConvert.DeserializeObject<Wrapper>(@"{ ""TimeSpanEx"" : { ""Hours"" : 1, ""Minutes"" : 2, ""Seconds"" : 3, ""RunOnVaultStartup"" : false } }");
 			Assert.IsNotNull(output?.TimeSpanEx);
 			Assert.AreEqual(new TimeSpan(01, 02, 03), output.TimeSpanEx.GetInterval());
 		}
@@ -65,28 +65,28 @@ namespace MFiles.VAF.Extensions.Tests.Configuration
 		{
 			var input = new TimeSpanEx(new TimeSpan(1, 2, 3));
 			// Note: we force RunOnVaultStartup to true for TimeSpanEx/TimeSpan, for legacy compatibility.
-			Assert.AreEqual(@"{""Hours"":1,""Minutes"":2,""Seconds"":3,""RunOnVaultStartup"":true}", JsonConvert.SerializeObject(input));
+			Assert.AreEqual(@"{""Hours"":1,""Minutes"":2,""Seconds"":3,""RunOnVaultStartup"":true}", Newtonsoft.Json.JsonConvert.SerializeObject(input));
 		}
 
 		[TestMethod]
 		public void SerializesCorrectlyWithRunOnVaultStartup_Null()
 		{
 			var input = new TimeSpanEx(new TimeSpan(1, 2, 3)) { RunOnVaultStartup = null };
-			Assert.AreEqual(@"{""Hours"":1,""Minutes"":2,""Seconds"":3}", JsonConvert.SerializeObject(input));
+			Assert.AreEqual(@"{""Hours"":1,""Minutes"":2,""Seconds"":3}", Newtonsoft.Json.JsonConvert.SerializeObject(input));
 		}
 
 		[TestMethod]
 		public void SerializesCorrectlyWithRunOnVaultStartup_True()
 		{
 			var input = new TimeSpanEx(new TimeSpan(1, 2, 3)) { RunOnVaultStartup = true };
-			Assert.AreEqual(@"{""Hours"":1,""Minutes"":2,""Seconds"":3,""RunOnVaultStartup"":true}", JsonConvert.SerializeObject(input));
+			Assert.AreEqual(@"{""Hours"":1,""Minutes"":2,""Seconds"":3,""RunOnVaultStartup"":true}", Newtonsoft.Json.JsonConvert.SerializeObject(input));
 		}
 
 		[TestMethod]
 		public void SerializesCorrectlyWithRunOnVaultStartup_False()
 		{
 			var input = new TimeSpanEx(new TimeSpan(1, 2, 3)) { RunOnVaultStartup = false };
-			Assert.AreEqual(@"{""Hours"":1,""Minutes"":2,""Seconds"":3,""RunOnVaultStartup"":false}", JsonConvert.SerializeObject(input));
+			Assert.AreEqual(@"{""Hours"":1,""Minutes"":2,""Seconds"":3,""RunOnVaultStartup"":false}", Newtonsoft.Json.JsonConvert.SerializeObject(input));
 		}
 	}
 }

--- a/MFiles.VAF.Extensions.Tests/Configuration/Upgrading/Rules/EnsureLatestSerializationSettingsUpgradeRuleTests.cs
+++ b/MFiles.VAF.Extensions.Tests/Configuration/Upgrading/Rules/EnsureLatestSerializationSettingsUpgradeRuleTests.cs
@@ -1,4 +1,5 @@
 ﻿using MFiles.VAF.Configuration;
+using MFiles.VAF.Configuration.JsonAdaptor;
 using MFiles.VAF.Extensions.Configuration;
 using MFiles.VAF.Extensions.Configuration.Upgrading;
 using MFiles.VAF.Extensions.ExtensionMethods;
@@ -15,6 +16,7 @@ using System.Linq;
 using System.Runtime.Serialization;
 using System.Text;
 using System.Threading.Tasks;
+using static MFiles.VAF.Extensions.Tests.Configuration.Upgrading.Rules.EnsureLatestSerializationSettingsUpgradeRuleTests;
 
 namespace MFiles.VAF.Extensions.Tests.Configuration.Upgrading.Rules
 {
@@ -611,6 +613,60 @@ namespace MFiles.VAF.Extensions.Tests.Configuration.Upgrading.Rules
 
 			Assert.IsTrue(rule.Execute(vault));
 			Assert.That.AreEqualJson("{\"Hello\": 0}", rule.GetReadWriteLocationValue(vault));
+
+		}
+
+		[DataContract]
+		private class ConfigurationWithSearchConditionsJA
+		{
+			[DataMember]
+			public SearchConditionsJA SearchConditions { get; set; }
+				= new SearchConditionsJA();
+		}
+
+		[TestMethod]
+		public void LoggingUpgrade_ConfigurationWithSearchConditionsJA()
+		{
+			var vault = Mock.Of<Vault>();
+			var rule = new EnsureLatestSerializationSettingsUpgradeRuleProxy<ConfigurationWithSearchConditionsJA>();
+			rule.SetReadWriteLocation(MFNamedValueType.MFConfigurationValue, "sampleNamespace", "config");
+			rule.SetReadWriteLocationValue(vault, @"{
+    ""SearchConditions"": [
+        {
+            ""conditionType"": ""equal"",
+            ""expression"": {
+                ""type"": ""propertyValue"",
+                ""propertyDef"": ""{82490C2F-8FB2-423B-85B5-F4ADB214C0FD}"",
+                ""indirectionLevels"": []
+            },
+            ""typedValue"": {
+                ""dataType"": ""lookup"",
+                ""value"": {
+                    ""isNull"": true
+                }
+            }
+        }
+    ]
+}");
+
+			Assert.IsTrue(rule.Execute(vault));
+			Assert.That.AreEqualJson(@"{
+    ""SearchConditions"": [
+        {
+            ""conditionType"": ""equal"",
+            ""expression"": {
+                ""type"": ""propertyValue"",
+                ""propertyDef"": ""{82490C2F-8FB2-423B-85B5-F4ADB214C0FD}""
+            },
+            ""typedValue"": {
+                ""dataType"": ""lookup"",
+                ""value"": {
+                    ""isNull"": true
+                }
+            }
+        }
+    ]
+}", rule.GetReadWriteLocationValue(vault));
 
 		}
 	}

--- a/MFiles.VAF.Extensions/Configuration/Frequency.cs
+++ b/MFiles.VAF.Extensions/Configuration/Frequency.cs
@@ -167,7 +167,7 @@ namespace MFiles.VAF.Extensions
 						? this.ReadJson(reader, objectType, existingValue, serializer)
 						: default;
 				case JsonToken.String:
-					var timeSpanEx = JsonConvert.DeserializeObject<TimeSpanEx>($"\"{reader.Value?.ToString()}\"");
+					var timeSpanEx = Newtonsoft.Json.JsonConvert.DeserializeObject<TimeSpanEx>($"\"{reader.Value?.ToString()}\"");
 					return new Frequency() { Interval = timeSpanEx, RecurrenceType = RecurrenceType.Interval };
 				case JsonToken.StartObject:
 

--- a/MFiles.VAF.Extensions/Configuration/JsonConverterBase.cs
+++ b/MFiles.VAF.Extensions/Configuration/JsonConverterBase.cs
@@ -39,7 +39,7 @@ namespace MFiles.VAF.Extensions
 
 				// Add it to the object.
 				writer.WritePropertyName(name);
-				writer.WriteRawValue(JsonConvert.SerializeObject(memberValue, Formatting.Indented));
+				writer.WriteRawValue(Newtonsoft.Json.JsonConvert.SerializeObject(memberValue, Formatting.Indented));
 
 			}
 
@@ -63,7 +63,7 @@ namespace MFiles.VAF.Extensions
 
 				// Add it to the object.
 				writer.WritePropertyName(name);
-				writer.WriteRawValue(JsonConvert.SerializeObject(memberValue, Formatting.Indented));
+				writer.WriteRawValue(Newtonsoft.Json.JsonConvert.SerializeObject(memberValue, Formatting.Indented));
 
 			}
 

--- a/MFiles.VAF.Extensions/Configuration/Upgrading/ConfigurationUpgradeManager.cs
+++ b/MFiles.VAF.Extensions/Configuration/Upgrading/ConfigurationUpgradeManager.cs
@@ -6,12 +6,14 @@ using MFilesAPI;
 using Newtonsoft.Json.Linq;
 using System;
 using System.Collections.Generic;
+using System.Data;
+using System.Diagnostics;
 using System.Linq;
 using System.Reflection;
 
 namespace MFiles.VAF.Extensions.Configuration.Upgrading
 {
-	internal class ConfigurationUpgradeManager
+	public class ConfigurationUpgradeManager
 		: IConfigurationUpgradeManager
 	{
 		private ILogger Logger { get; } = LogManager.GetLogger(typeof(ConfigurationUpgradeManager));
@@ -46,27 +48,43 @@ namespace MFiles.VAF.Extensions.Configuration.Upgrading
 				// Clear anything we've previously scanned.
 				this.CheckedConfigurationUpgradeTypes.Clear();
 
-				// Run any configuration upgrade rules.
+				// Get any configuration upgrade rules.
+				var upgradeStopwatch = new Stopwatch();
+				upgradeStopwatch.Start();
 				var rules = this.GetAppropriateUpgradeRules<TSecureConfiguration>(vault) ?? Enumerable.Empty<IUpgradeRule>();
+
+				if (!rules.Any())
+				{
+					this.Logger?.Info($"Skipping configuration upgrade as there were no appropriate rules.");
+					return;
+				}
+
+				// Run the rules.
+				int ruleCount = 0;
 				foreach (var rule in rules)
 				{
+					ruleCount++;
 					try
 					{
+						var ruleStopwatch = new Stopwatch();
+						ruleStopwatch.Start();
 						rule?.Execute(vault);
+						ruleStopwatch.Stop();
+						this.Logger?.Debug($"Took {ruleStopwatch.ElapsedMilliseconds}ms to run rule of type {rule.GetType().FullName} ({rule.MigrateFromVersion?.ToString()}-{rule.MigrateToVersion?.ToString()}).");
 					}
 					catch (Exception ex)
 					{
 						this.Logger?.Error(ex, $"Could not execute configuration upgrade/migration rule of type {rule?.GetType()?.FullName}");
 					}
 				}
-
+				upgradeStopwatch.Stop();
+				this.Logger?.Info($"Took {upgradeStopwatch.ElapsedMilliseconds}ms to upgrade configuration ({ruleCount} rules).");
 			}
 			catch (Exception e)
 			{
 				this.Logger?.Fatal(e, $"Could not get configuration upgrade rules.");
 			}
 		}
-
 		protected virtual IEnumerable<IUpgradeRule> GetAppropriateUpgradeRules<TSecureConfiguration>(Vault vault)
 			where TSecureConfiguration : class, new()
 		{

--- a/MFiles.VAF.Extensions/Configuration/Upgrading/ConfigurationUpgradeManager.cs
+++ b/MFiles.VAF.Extensions/Configuration/Upgrading/ConfigurationUpgradeManager.cs
@@ -51,7 +51,8 @@ namespace MFiles.VAF.Extensions.Configuration.Upgrading
 				// Get any configuration upgrade rules.
 				var upgradeStopwatch = new Stopwatch();
 				upgradeStopwatch.Start();
-				var rules = this.GetAppropriateUpgradeRules<TSecureConfiguration>(vault) ?? Enumerable.Empty<IUpgradeRule>();
+				var rules = (this.GetAppropriateUpgradeRules<TSecureConfiguration>(vault) ?? Enumerable.Empty<IUpgradeRule>())
+					.ToList();
 
 				if (!rules.Any())
 				{
@@ -60,10 +61,8 @@ namespace MFiles.VAF.Extensions.Configuration.Upgrading
 				}
 
 				// Run the rules.
-				int ruleCount = 0;
 				foreach (var rule in rules)
 				{
-					ruleCount++;
 					try
 					{
 						var ruleStopwatch = new Stopwatch();
@@ -78,7 +77,7 @@ namespace MFiles.VAF.Extensions.Configuration.Upgrading
 					}
 				}
 				upgradeStopwatch.Stop();
-				this.Logger?.Info($"Took {upgradeStopwatch.ElapsedMilliseconds}ms to upgrade configuration ({ruleCount} rules).");
+				this.Logger?.Info($"Took {upgradeStopwatch.ElapsedMilliseconds}ms to upgrade configuration ({rules.Count} rules).");
 			}
 			catch (Exception e)
 			{

--- a/MFiles.VAF.Extensions/Dashboards/Commands/ShowLatestLogEntriesDashboardCommand.cs
+++ b/MFiles.VAF.Extensions/Dashboards/Commands/ShowLatestLogEntriesDashboardCommand.cs
@@ -100,7 +100,7 @@ namespace MFiles.VAF.Extensions.Dashboards.Commands
 			// Inject the log file list into the dashboard template.
 			var downloadMethod = clientOps.Manager.CreateCommandMethodSource(
 					clientOps.DefaultNodeLocation, RetrieveLatestLogEntriesCommand.CommandId);
-			string downloadMethodJson = JsonConvert.SerializeObject(downloadMethod);
+			string downloadMethodJson = Newtonsoft.Json.JsonConvert.SerializeObject(downloadMethod);
 			string dashboard = template
 				.Replace("%RETRIEVELOGENTRIES_METHOD%", downloadMethodJson)
 				.Replace("%IMG_WARNING_DATAURI%", DashboardHelpersEx.ImageFileToDataUri("Resources/Images/warning.png"));
@@ -158,7 +158,7 @@ namespace MFiles.VAF.Extensions.Dashboards.Commands
 			// Resolve the files to download from the input params.
 			var envContext = (EventHandlerRequestContext)context;
 			int methodIndex = envContext.Environment.InputParams.FindIndex(a => a == CommandId);
-			var requestParameters = JsonConvert.DeserializeObject<RequestParameters>
+			var requestParameters = Newtonsoft.Json.JsonConvert.DeserializeObject<RequestParameters>
 				(
 					envContext.Environment.InputParams.Skip(methodIndex + 1).FirstOrDefault() ?? "{}"
 				);
@@ -172,7 +172,7 @@ namespace MFiles.VAF.Extensions.Dashboards.Commands
 				// Nothing will ever match; let's not dig through the files.
 				clientOps.Directives.Add(new VAF.Configuration.Domain.ClientDirective.UpdateDashboardContent()
 				{
-					Content = JsonConvert.SerializeObject(logEntries)
+					Content = Newtonsoft.Json.JsonConvert.SerializeObject(logEntries)
 				});
 				return;
 			}
@@ -275,7 +275,7 @@ namespace MFiles.VAF.Extensions.Dashboards.Commands
 			// Create the directive.
 			clientOps.Directives.Add(new VAF.Configuration.Domain.ClientDirective.UpdateDashboardContent()
 			{
-				Content = JsonConvert.SerializeObject(logEntries)
+				Content = Newtonsoft.Json.JsonConvert.SerializeObject(logEntries)
 			});
 
 		}

--- a/MFiles.VAF.Extensions/Dashboards/Commands/ShowSelectLogDownloadDashboardCommand.cs
+++ b/MFiles.VAF.Extensions/Dashboards/Commands/ShowSelectLogDownloadDashboardCommand.cs
@@ -90,11 +90,11 @@ namespace MFiles.VAF.Extensions.Dashboards.Commands
 			}
 
 			// Inject the log file list into the dashboard template.
-			string logFilesJson = JsonConvert.SerializeObject(
+			string logFilesJson = Newtonsoft.Json.JsonConvert.SerializeObject(
 					logFiles.OrderByDescending(f => f.RelativePath));
 			var downloadMethod = clientOps.Manager.CreateCommandMethodSource(
 					clientOps.DefaultNodeLocation, DownloadSelectedLogsDashboardCommand.CommandId);
-			string downloadMethodJson = JsonConvert.SerializeObject(downloadMethod);
+			string downloadMethodJson = Newtonsoft.Json.JsonConvert.SerializeObject(downloadMethod);
 			string dashboard = template
 					.Replace("%LOG_FILES_DATA%", logFilesJson)
 					.Replace("%DOWNLOAD_METHOD%", downloadMethodJson);

--- a/MFiles.VAF.Extensions/ExtensionMethods/ApplicationTaskInfoExtensionMethods.cs
+++ b/MFiles.VAF.Extensions/ExtensionMethods/ApplicationTaskInfoExtensionMethods.cs
@@ -38,7 +38,7 @@ namespace MFiles.VAF.Extensions
 			// Try and parse the remarks into the expected type.
 			try
 			{
-				var info = JsonConvert.DeserializeObject<TTaskInformation>(serialisedContent);
+				var info = Newtonsoft.Json.JsonConvert.DeserializeObject<TTaskInformation>(serialisedContent);
 				if (null != info)
 					info.CurrentTaskState = applicationTask.State;
 				return info;

--- a/MFiles.VAF.Extensions/IJsonConvert.cs
+++ b/MFiles.VAF.Extensions/IJsonConvert.cs
@@ -3,6 +3,7 @@ using MFiles.VAF.Configuration.JsonAdaptor;
 using MFiles.VAF.Configuration.Logging;
 using MFiles.VAF.Extensions.Configuration;
 using MFiles.VAF.Extensions.Configuration.Upgrading;
+using MFiles.VAF.Extensions.Configuration.Upgrading.Rules;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Converters;
 using Newtonsoft.Json.Serialization;
@@ -54,6 +55,31 @@ namespace MFiles.VAF.Extensions
 		string Serialize(object input, Type t);
 	}
 
+	public abstract class JsonConvert
+		: IJsonConvert
+	{
+		/// <inheritdoc />
+		public abstract T Deserialize<T>(string input);
+
+		/// <inheritdoc />
+		public abstract object Deserialize(string input, Type type);
+
+		/// <inheritdoc />
+		public abstract string Serialize<T>(T input);
+
+		/// <inheritdoc />
+		public abstract string Serialize(object input, Type t);
+
+		/// <summary>
+		/// If these types are found then their default values are left intact
+		/// when converting the JSON.
+		/// </summary>
+		public static List<string> DefaultValueSkippedTypes { get; } = new List<string>()
+		{
+			"MFiles.VAF.Configuration.JsonAdaptor.JsonValueAdaptor"
+		};
+	}
+
 	/// <summary>
 	/// An implementation of <see cref="IJsonConvert"/>
 	/// that delegates to Newtonsoft.
@@ -65,8 +91,8 @@ namespace MFiles.VAF.Extensions
 		{
 			protected IJsonConvert JsonConvert { get; set; }
 			private ILogger Logger { get; } = LogManager.GetLogger(typeof(DefaultValueAwareValueProvider));
-			private MemberInfo memberInfo;
-			private IValueProvider valueProvider;
+			private readonly MemberInfo memberInfo;
+			private readonly IValueProvider valueProvider;
 			public DefaultValueAwareValueProvider(IJsonConvert jsonConvert, MemberInfo memberInfo, IValueProvider valueProvider)
 			{
 				this.JsonConvert = jsonConvert
@@ -136,9 +162,31 @@ namespace MFiles.VAF.Extensions
 							}
 					}
 
-					// If this is a JsonValueAdaptor then include it all regardless (fixes issue with search conditions).
-					if (type == typeof(JsonValueAdaptor))
-						return value;
+					// Is this type part of the skipped types?
+					if (null != Extensions.JsonConvert.DefaultValueSkippedTypes)
+					{
+						foreach (var s in Extensions.JsonConvert.DefaultValueSkippedTypes)
+						{
+							// Sanity.
+							if (null == s)
+								continue;
+
+							// Is it a prefix or an exact match?
+							if (s.EndsWith("*"))
+							{
+								// It's a prefix.
+								var prefix = s.Substring(0, s.Length - 1);
+								if (type.FullName.StartsWith(prefix, StringComparison.OrdinalIgnoreCase))
+									return value;
+							}
+							else
+							{
+								// Exact match.
+								if (type.FullName.Equals(s, StringComparison.OrdinalIgnoreCase))
+									return value;
+							}
+						}
+					}
 
 					// If the property has no default value, try to get the default of that type.
 					try

--- a/MFiles.VAF.Extensions/IJsonConvert.cs
+++ b/MFiles.VAF.Extensions/IJsonConvert.cs
@@ -1,4 +1,5 @@
 ﻿using MFiles.VAF.Configuration;
+using MFiles.VAF.Configuration.JsonAdaptor;
 using MFiles.VAF.Configuration.Logging;
 using MFiles.VAF.Extensions.Configuration;
 using MFiles.VAF.Extensions.Configuration.Upgrading;
@@ -6,6 +7,7 @@ using Newtonsoft.Json;
 using Newtonsoft.Json.Converters;
 using Newtonsoft.Json.Serialization;
 using System;
+using System.CodeDom;
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
@@ -134,6 +136,10 @@ namespace MFiles.VAF.Extensions
 							}
 					}
 
+					// If this is a JsonValueAdaptor then include it all regardless (fixes issue with search conditions).
+					if (type == typeof(JsonValueAdaptor))
+						return value;
+
 					// If the property has no default value, try to get the default of that type.
 					try
 					{
@@ -154,9 +160,11 @@ namespace MFiles.VAF.Extensions
 						return null;
 					if (defaultValue == value)
 						return null;
-					var serializedValue = this.JsonConvert.Serialize(value ?? "{}");
-					if (serializedValue == "{}" 
-						|| this.JsonConvert.Serialize(defaultValue) == serializedValue)
+
+					var serializedValue = null == value ? "{}" : this.JsonConvert.Serialize(value);
+					var serializedDefaultValue = null == defaultValue ? "{}" : this.JsonConvert.Serialize(defaultValue);
+
+					if (serializedValue == "{}" || serializedDefaultValue == serializedValue)
 						return null;
 				}
 				catch(Exception e)

--- a/MFiles.VAF.Extensions/TaskQueueBackgroundOperations/BackgroundOperationTaskDirective.cs
+++ b/MFiles.VAF.Extensions/TaskQueueBackgroundOperations/BackgroundOperationTaskDirective.cs
@@ -101,7 +101,7 @@ namespace MFiles.VAF.Extensions
 		{
 			return this.InternalDirectiveForSerialization == null
 				? null
-				: JsonConvert.DeserializeObject
+				: Newtonsoft.Json.JsonConvert.DeserializeObject
 				(
 					this.InternalDirectiveForSerialization.AsString(Encoding.UTF8),
 					Type.GetType(this.InternalDirectiveTypeForSerialization)


### PR DESCRIPTION
More control available to developers to allow default values to be left intact in the JSON.  In addition to the previously-available `AllowDefaultValueSerializationAttribute` attribute, names of types can now be added to the `MFiles.VAF.Extensions.JsonConvert.DefaultValueSkippedTypes` collection.

This approach is useful where the property or type being output cannot have the `AllowDefaultValueSerializationAttribute` applied, such as types within the VAF itself.

Any types in this collection are skipped from the "remove default values" logic.  By default this collection contains a single value "MFiles.VAF.Configuration.JsonAdaptor.JsonValueAdaptor", although this may be extended in the future either within the extensions library or by consuming applications.