### PR TITLE
Hide dashboard load download/view buttons in unsupported M-Files versions

### DIFF
--- a/MFiles.VAF.Extensions/ConfigurableVaultApplicationBase.GetDashboardContent.cs
+++ b/MFiles.VAF.Extensions/ConfigurableVaultApplicationBase.GetDashboardContent.cs
@@ -218,7 +218,7 @@ namespace MFiles.VAF.Extensions
 		/// </summary>
 		/// <returns>The dashboard content.  Can be null if no logging data is available or configured.</returns>
 		public virtual IDashboardContent GetLoggingDashboardContent(IConfigurationRequestContext context)
-			=> this.LoggingDashboardContentRenderer?.GetDashboardContent(this.GetLoggingConfiguration());
+			=> this.LoggingDashboardContentRenderer?.GetDashboardContent(context, this.GetLoggingConfiguration());
 
 		#endregion
 

--- a/MFiles.VAF.Extensions/Dashboards/LoggingDashboardContent/DashboardListLoggingDashboardContentRenderer.cs
+++ b/MFiles.VAF.Extensions/Dashboards/LoggingDashboardContent/DashboardListLoggingDashboardContentRenderer.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Linq;
 using MFiles.VAF.Configuration.Logging;
 using MFiles.VAF.Configuration.Logging.Targets;
+using MFiles.VAF.Configuration.AdminConfigurations;
 
 namespace MFiles.VAF.Extensions.Dashboards.LoggingDashboardContent
 {
@@ -27,7 +28,11 @@ namespace MFiles.VAF.Extensions.Dashboards.LoggingDashboardContent
 		/// </summary>
 		protected bool AllowDashboardLogEntryViewing { get; set; } = true;
 
-		public virtual DashboardPanelEx GetDashboardContent(ILoggingConfiguration loggingConfiguration)
+		public virtual DashboardPanelEx GetDashboardContent
+		(
+			IConfigurationRequestContext context,
+			ILoggingConfiguration loggingConfiguration
+		)
 		{
 			// If we don't have any logging configuration then return null.
 			if (loggingConfiguration == null)
@@ -106,25 +111,28 @@ namespace MFiles.VAF.Extensions.Dashboards.LoggingDashboardContent
 				{
 					// Add whatever buttons, according to app configuration.
 					var buttons = new DashboardContentCollection();
-					if (this.AllowDashboardLogFileDownload)
+					if (false == string.IsNullOrWhiteSpace(Commands.DefaultLogDashboardCommandBase.ResolveRootLogPath(context?.Vault)))
 					{
-						buttons.Add(new DashboardDomainCommandEx
+						if (this.AllowDashboardLogFileDownload)
 						{
-							DomainCommandID = this.AllowUserToSelectLogFiles
-									? Dashboards.Commands.ShowSelectLogDownloadDashboardCommand.CommandId
-									: Dashboards.Commands.DownloadSelectedLogsDashboardCommand.CommandId,
-							Title = Resources.Dashboard.Logging_Table_DownloadLogs,
-							Icon = "Resources/Images/Download.png"
-						});
-					}
-					if (this.AllowDashboardLogEntryViewing)
-					{
-						buttons.Add(new DashboardDomainCommandEx
+							buttons.Add(new DashboardDomainCommandEx
+							{
+								DomainCommandID = this.AllowUserToSelectLogFiles
+										? Dashboards.Commands.ShowSelectLogDownloadDashboardCommand.CommandId
+										: Dashboards.Commands.DownloadSelectedLogsDashboardCommand.CommandId,
+								Title = Resources.Dashboard.Logging_Table_DownloadLogs,
+								Icon = "Resources/Images/Download.png"
+							});
+						}
+						if (this.AllowDashboardLogEntryViewing)
 						{
-							DomainCommandID = Dashboards.Commands.ShowLatestLogEntriesDashboardCommand.CommandId,
-							Title = Resources.Dashboard.Logging_Table_ShowLatestLogEntries,
-							Icon = "Resources/Images/viewlogs.png"
-						});
+							buttons.Add(new DashboardDomainCommandEx
+							{
+								DomainCommandID = Dashboards.Commands.ShowLatestLogEntriesDashboardCommand.CommandId,
+								Title = Resources.Dashboard.Logging_Table_ShowLatestLogEntries,
+								Icon = "Resources/Images/viewlogs.png"
+							});
+						}
 					}
 
 					// Add the buttons to the cell
@@ -163,7 +171,11 @@ namespace MFiles.VAF.Extensions.Dashboards.LoggingDashboardContent
 			};
 		}
 
-		IDashboardContent ILoggingDashboardContentRenderer.GetDashboardContent(ILoggingConfiguration loggingConfiguration)
-			=> this.GetDashboardContent(loggingConfiguration);
+		IDashboardContent ILoggingDashboardContentRenderer.GetDashboardContent
+		(
+			IConfigurationRequestContext context,
+			ILoggingConfiguration loggingConfiguration
+		)
+			=> this.GetDashboardContent(context, loggingConfiguration);
 	}
 }

--- a/MFiles.VAF.Extensions/Dashboards/LoggingDashboardContent/DashboardListLoggingDashboardContentRenderer.cs
+++ b/MFiles.VAF.Extensions/Dashboards/LoggingDashboardContent/DashboardListLoggingDashboardContentRenderer.cs
@@ -111,6 +111,8 @@ namespace MFiles.VAF.Extensions.Dashboards.LoggingDashboardContent
 				{
 					// Add whatever buttons, according to app configuration.
 					var buttons = new DashboardContentCollection();
+
+					// If the M-Files version is old and can't provide a default log location then don't render the buttons.
 					if (false == string.IsNullOrWhiteSpace(Commands.DefaultLogDashboardCommandBase.ResolveRootLogPath(context?.Vault)))
 					{
 						if (this.AllowDashboardLogFileDownload)

--- a/MFiles.VAF.Extensions/Dashboards/LoggingDashboardContent/ILoggingDashboardContentRenderer.cs
+++ b/MFiles.VAF.Extensions/Dashboards/LoggingDashboardContent/ILoggingDashboardContentRenderer.cs
@@ -1,4 +1,5 @@
-﻿using MFiles.VAF.Configuration.Domain.Dashboards;
+﻿using MFiles.VAF.Configuration.AdminConfigurations;
+using MFiles.VAF.Configuration.Domain.Dashboards;
 using MFiles.VAF.Configuration.Logging;
 
 namespace MFiles.VAF.Extensions.Dashboards.LoggingDashboardContent
@@ -9,6 +10,10 @@ namespace MFiles.VAF.Extensions.Dashboards.LoggingDashboardContent
 		/// Gets the logging dashboard content.
 		/// </summary>
 		/// <returns>The content, or null if nothing to render.</returns>
-		IDashboardContent GetDashboardContent(ILoggingConfiguration loggingConfiguration);
+		IDashboardContent GetDashboardContent
+		(
+			IConfigurationRequestContext context, 
+			ILoggingConfiguration loggingConfiguration
+		);
 	}
 }


### PR DESCRIPTION
If the M-Files version does not have sufficient data to provide a path for the default log location (e.g. the version is very old) then hide the default log download/view buttons on the dashboard (as these fail anyway).