### PR TITLE
IStableValueOptionsProvider that exposes enum values correctly serialised.

### DIFF
--- a/MFiles.VAF.Extensions.Tests/Configuration/Upgrading/Rules/EnsureLatestSerializationSettingsUpgradeRuleTests.cs
+++ b/MFiles.VAF.Extensions.Tests/Configuration/Upgrading/Rules/EnsureLatestSerializationSettingsUpgradeRuleTests.cs
@@ -1,4 +1,6 @@
 ﻿using MFiles.VAF.Configuration;
+using MFiles.VAF.Configuration.AdminConfigurations;
+using MFiles.VAF.Configuration.JsonEditor;
 using MFiles.VAF.Extensions.Configuration;
 using MFiles.VAF.Extensions.Configuration.Upgrading;
 using MFiles.VAF.Extensions.ExtensionMethods;
@@ -613,5 +615,85 @@ namespace MFiles.VAF.Extensions.Tests.Configuration.Upgrading.Rules
 			Assert.That.AreEqualJson("{\"Hello\": 0}", rule.GetReadWriteLocationValue(vault));
 
 		}
+
+		#region IStableValueOptionsProvider
+
+		// Using this approach always stored enum values as integers; ensure we respect that.
+
+		public class MyOptionsProvided
+			: IStableValueOptionsProvider
+		{
+			/// <summary>
+			/// Options getter for MyOptions.
+			/// </summary>
+			/// <param name="context">Unused context.</param>
+			/// <returns></returns>
+			public IEnumerable<ValueOption> GetOptions(IConfigurationRequestContext context)
+			{
+				// Yield the available options.
+				yield return new ValueOption
+				{
+					Label = "First Value",
+					Value = ConfigurationWithStableValuesOptionProvider.MyOptions.FirstValue
+				};
+				yield return new ValueOption
+				{
+					Label = "Second Value",
+					Value = ConfigurationWithStableValuesOptionProvider.MyOptions.SecondValue
+				};
+				yield return new ValueOption
+				{
+					Label = "Third Value",
+					Value = ConfigurationWithStableValuesOptionProvider.MyOptions.ThirdValue
+				};
+			}
+		}
+
+		[DataContract]
+		public class ConfigurationWithStableValuesOptionProvider
+		{
+			public enum MyOptions
+			{
+				FirstValue = 10,
+				SecondValue = 20,
+				ThirdValue = 30,
+			}
+
+
+			[DataMember]
+			[JsonConfEditor(
+				Label = "Normal Enum",
+				DefaultValue = MyOptions.FirstValue)]
+			public MyOptions NormalEnum { get; set; }
+
+			[DataMember]
+			[JsonConfEditor(
+				Label = "Enum Options Provided",
+				TypeEditor = "options",
+				DefaultValue = MyOptions.FirstValue)]
+			[ValueOptions(typeof(MyOptionsProvided))]
+			public MyOptions EnumOptionsProvided { get; set; }
+		}
+
+		[TestMethod]
+		public void StableValueOptionsEnumValuesAreStoredAsIntegers()
+		{
+			var vault = Mock.Of<Vault>();
+			var rule = new EnsureLatestSerializationSettingsUpgradeRuleProxy<ConfigurationWithStableValuesOptionProvider>();
+			rule.SetReadWriteLocation(MFNamedValueType.MFConfigurationValue, "sampleNamespace", "config");
+			rule.SetReadWriteLocationValue(vault, @"{
+				""NormalEnum"" : ""SecondValue"",
+				""EnumOptionsProvided"" : ""30""
+			}");
+
+			Assert.IsTrue(rule.Execute(vault));
+			Assert.That.AreEqualJson(@"{
+				""NormalEnum"" : ""SecondValue"",
+				""EnumOptionsProvided"" : ""30""
+			}", rule.GetReadWriteLocationValue(vault));
+		}
+
+		#endregion
+
 	}
 }

--- a/MFiles.VAF.Extensions/IJsonConvert.cs
+++ b/MFiles.VAF.Extensions/IJsonConvert.cs
@@ -1,4 +1,5 @@
 ﻿using MFiles.VAF.Configuration;
+using MFiles.VAF.Configuration.JsonEditor;
 using MFiles.VAF.Configuration.Logging;
 using MFiles.VAF.Extensions.Configuration;
 using MFiles.VAF.Extensions.Configuration.Upgrading;
@@ -8,6 +9,7 @@ using Newtonsoft.Json.Serialization;
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
@@ -116,6 +118,7 @@ namespace MFiles.VAF.Extensions
 					object defaultValue = null;
 					var instance = Activator.CreateInstance(this.memberInfo.ReflectedType);
 					Type type = null;
+					bool hasValueOptionsAttribute = false;
 					switch(this.memberInfo.MemberType)
 					{
 						case MemberTypes.Field:
@@ -123,6 +126,7 @@ namespace MFiles.VAF.Extensions
 								var fieldInfo = (FieldInfo)this.memberInfo;
 								type = fieldInfo.FieldType;
 								defaultValue = fieldInfo.GetValue(instance);
+								hasValueOptionsAttribute = fieldInfo.GetCustomAttribute<ValueOptionsAttribute>() != null;
 							break;
 							}
 						case MemberTypes.Property:
@@ -130,6 +134,7 @@ namespace MFiles.VAF.Extensions
 								var propertyInfo = (PropertyInfo)this.memberInfo;
 								type = propertyInfo.PropertyType;
 								defaultValue = propertyInfo.GetValue(instance);
+								hasValueOptionsAttribute = propertyInfo.GetCustomAttribute<ValueOptionsAttribute>() != null;
 								break;
 							}
 					}
@@ -148,6 +153,31 @@ namespace MFiles.VAF.Extensions
 						};
 					}
 					catch { } // Nope.
+
+					// If the type is an enum, but it has a ValueOptionsAttribute, then serialize as an integer.
+					if(type.IsEnum && hasValueOptionsAttribute)
+					{
+						try
+						{
+							value = (int)value;
+						}
+						catch (Exception e)
+						{
+							// Could not convert to integer.
+							this.Logger?.Warn(e, $"Could not convert {this.memberInfo.ReflectedType.FullName}.{this.memberInfo.Name} value to an integer ({value}).");
+							return value;
+						}
+						try
+						{
+							defaultValue = (int)defaultValue;
+						}
+						catch (Exception e)
+						{
+							// Could not convert to integer.
+							this.Logger?.Warn(e, $"Could not convert {type.FullName} default value to an integer ({defaultValue}).");
+							return value;
+						}
+					}
 
 					// If the data is the same as the default value then do not serialize.
 					if (type == typeof(string) && string.Equals(defaultValue, value))
@@ -188,6 +218,40 @@ namespace MFiles.VAF.Extensions
 
 				// Return the value that the base implementation gave.
 				return value;
+			}
+		}
+
+		/// <summary>
+		/// A class to write enums as either integers or strings, depending on what's provided.
+		/// </summary>
+		internal class StringEnumConverterHandlesIntegers 
+			: StringEnumConverter
+		{
+			public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
+			{
+				// Sanity.
+				if (null == writer 
+					|| null == value
+					|| null == serializer)
+					return;
+
+				// If it's an enum then write it as an enum.
+				try
+				{
+					var enumValue = (Enum)value;
+					base.WriteJson(writer, value, serializer);
+					return;
+				}
+				catch
+				{
+					// If we can write integers then awesome.
+					if (AllowIntegerValues && value.GetType() == typeof(int))
+					{
+						writer.WriteValue(value);
+						return;
+					}
+				}
+				throw new JsonSerializationException($"Value {value} ({value.GetType().FullName}) not supported by StringEnumConverterHandlesIntegers.");
 			}
 		}
 
@@ -312,7 +376,7 @@ namespace MFiles.VAF.Extensions
 				Formatting = Newtonsoft.Json.Formatting.Indented,
 				Converters = new List<JsonConverter>()
 					{
-						new StringEnumConverter()
+						new StringEnumConverterHandlesIntegers(){ AllowIntegerValues = true }
 					},
 				ContractResolver = new DefaultValueAwareContractResolver(this)
 			};


### PR DESCRIPTION
When IStableValueOptionsProvider is used and the return values are enums, they were previously serialised as integers (whereas enums were serialised as their names in all other parts).  The upgrade/conversion process broke this as the values were changed from integers to strings.

Added unit test that checks enum values in different scenarios.
Thanks Katriina!