### PR TITLE
Change versioning of pre-releases

### DIFF
--- a/.github/workflows/manual.yml
+++ b/.github/workflows/manual.yml
@@ -42,7 +42,16 @@ jobs:
     - name: Get version number
       shell: pwsh
       run: |
-        $versionNumber = Get-Date -Format "yy.M.${{ github.run_number }}"
+        If([string]::IsNullOrEmpty({{ env.versionSuffix }}))
+        {
+            # No suffix.  Fine.
+            $versionNumber = Get-Date -Format "yy.M.${{ github.run_number }}"
+        }
+        else
+        {
+            # Suffix; ensure we add .0 in version number to stop them appearing above full releases.
+            $versionNumber = Get-Date -Format "yy.M.0.${{ github.run_number }}"
+        }
         echo "versionNumber=$versionNumber${{ env.versionSuffix }}" | Out-File -FilePath $Env:GITHUB_ENV -Encoding utf-8 -Append
 
     - name: Write release notes


### PR DESCRIPTION
Previous prereleases could be listed above newer releases from the release branch.
Prereleases now contain a .0 inside their version string to ensure that they appear behind full releases that are made after them.