### PR TITLE
Fix for reported issue with [JsonConfEditor(EditorType = "date")]

### DIFF
--- a/MFiles.VAF.Extensions.Tests/Configuration/Upgrading/Rules/EnsureLatestSerializationSettingsUpgradeRuleTests.cs
+++ b/MFiles.VAF.Extensions.Tests/Configuration/Upgrading/Rules/EnsureLatestSerializationSettingsUpgradeRuleTests.cs
@@ -752,5 +752,34 @@ namespace MFiles.VAF.Extensions.Tests.Configuration.Upgrading.Rules
 		}
 
 		#endregion
+
+		[DataContract]
+		public sealed class DateTimeStoredAsDateConfiguration
+		{
+			[DataMember]
+			[JsonConfEditor(TypeEditor = "date", IsRequired = true)]
+			public DateTime? ReminderDate { get; set; }
+
+			[DataMember]
+			public DateTime? NormalDate { get; set; }
+		}
+
+		[TestMethod]
+		public void DateTimeStoredAsDate()
+		{
+			var vault = Mock.Of<Vault>();
+			var rule = new EnsureLatestSerializationSettingsUpgradeRuleProxy<DateTimeStoredAsDateConfiguration>();
+			rule.SetReadWriteLocation(MFNamedValueType.MFConfigurationValue, "sampleNamespace", "config");
+			rule.SetReadWriteLocationValue(vault, @"{
+				""ReminderDate"" : ""2023-05-02"",
+				""NormalDate"" : ""2020-12-31T01:02:03""
+			}");
+
+			Assert.IsTrue(rule.Execute(vault));
+			Assert.That.AreEqualJson(@"{
+				""ReminderDate"" : ""2023-05-02"",
+				""NormalDate"" : ""2020-12-31T01:02:03""
+			}", rule.GetReadWriteLocationValue(vault));
+		}
 	}
 }

--- a/MFiles.VAF.Extensions/Configuration/Upgrading/JsonConversion/NewtonsoftJsonConvert.cs
+++ b/MFiles.VAF.Extensions/Configuration/Upgrading/JsonConversion/NewtonsoftJsonConvert.cs
@@ -10,6 +10,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 using System.Runtime.Serialization;
+using static System.Net.Mime.MediaTypeNames;
 
 namespace MFiles.VAF.Extensions
 {
@@ -71,12 +72,12 @@ namespace MFiles.VAF.Extensions
 				}
 
 				// Try to get the runtime default value.
+				Type type = null;
 				try
 				{
 					// Create an instance of this type.
 					object defaultValue = null;
 					var instance = Activator.CreateInstance(this.memberInfo.ReflectedType);
-					Type type = null;
 					bool hasValueOptionsAttribute = false;
 					switch(this.memberInfo.MemberType)
 					{
@@ -184,27 +185,62 @@ namespace MFiles.VAF.Extensions
 				// If this member has a JsonConfEditorAttribute then we need to check whether to filter it.
 				{
 					var jsonConfEditorAttribute = this.memberInfo.GetCustomAttribute<JsonConfEditorAttribute>();
-					if(null != jsonConfEditorAttribute && null != jsonConfEditorAttribute.DefaultValue)
+					if(null != jsonConfEditorAttribute)
 					{
-						// If it is the default then die now.
-						if (value?.ToString() == jsonConfEditorAttribute.DefaultValue?.ToString())
-							return null;
-
-						// If it's the identifier then we need to check the alias/guid/id properties.
-						if(value is MFIdentifier identifier && (
-							identifier.Alias == jsonConfEditorAttribute.DefaultValue?.ToString()
-							|| identifier.Guid == jsonConfEditorAttribute.DefaultValue?.ToString()
-							|| identifier.ID.ToString() == jsonConfEditorAttribute.DefaultValue?.ToString()
-							))
+						if (null != jsonConfEditorAttribute.DefaultValue)
 						{
-							return null;
+							// If it is the default then die now.
+							if (value?.ToString() == jsonConfEditorAttribute.DefaultValue?.ToString())
+								return null;
+
+							// If it's the identifier then we need to check the alias/guid/id properties.
+							if (value is MFIdentifier identifier && (
+								identifier.Alias == jsonConfEditorAttribute.DefaultValue?.ToString()
+								|| identifier.Guid == jsonConfEditorAttribute.DefaultValue?.ToString()
+								|| identifier.ID.ToString() == jsonConfEditorAttribute.DefaultValue?.ToString()
+								))
+							{
+								return null;
+							}
 						}
+
+						// If the configuration value has a JsonConfEditor attribute that defines an editor type
+						// then we may need to convert our deserialized value.
+						if (jsonConfEditorAttribute.TypeEditor == "date" && value is DateTime dateTime)
+							value = dateTime.ToString("yyyy-MM-dd");
 
 					}
 				}
 
 				// Return the value that the base implementation gave.
 				return value;
+			}
+		}
+
+		/// <summary>
+		/// A class to write enums as either integers or strings, depending on what's provided.
+		/// </summary>
+		internal class DateTimeConverter
+			: Newtonsoft.Json.Converters.IsoDateTimeConverter
+		{
+
+			public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
+			{
+				// Sanity.
+				if (null == writer
+					|| null == value
+					|| null == serializer)
+					return;
+
+				// If it's a string then write it.
+				if(value.GetType() == typeof(string))
+				{
+					writer.WriteValue(value);
+					return;
+				}
+
+				// Use the base implementation.
+				base.WriteJson(writer, value, serializer);
 			}
 		}
 
@@ -363,7 +399,8 @@ namespace MFiles.VAF.Extensions
 				Formatting = Newtonsoft.Json.Formatting.Indented,
 				Converters = new List<JsonConverter>()
 					{
-						new StringEnumConverterHandlesIntegers(){ AllowIntegerValues = true }
+						new StringEnumConverterHandlesIntegers(){ AllowIntegerValues = true },
+						new DateTimeConverter()
 					},
 				ContractResolver = new DefaultValueAwareContractResolver(this)
 			};

--- a/MFiles.VAF.Extensions/Configuration/Upgrading/Readme.md
+++ b/MFiles.VAF.Extensions/Configuration/Upgrading/Readme.md
@@ -171,3 +171,19 @@ public class NewConfiguration
 ```
 
 NOTE: In the above example, `OldConfiguration` will be read from the custom NVS location but `NewConfiguration` will be written to the standard location.  This style configuration will effectively move the configuration; the old version is read from the custom location, deserialized, converted, then serialized and saved to the standard location.
+
+## Disabling configuration upgrading
+
+To completely disable configuration upgrading, return null from the `GetConfigurationUpgradeManager` method on your VaultApplication class:
+
+```csharp
+public class VaultApplication : MFiles.VAF.Extensions.ConfigurableVaultApplicationBase<Configuration>
+{
+    /// <inheritdoc />
+    /// <remarks>Configuration upgrading is disabled.</remarks>
+    public override IConfigurationUpgradeManager GetConfigurationUpgradeManager()
+	{
+		return null;
+	}
+}
+```


### PR DESCRIPTION
Confirmed as fixed in community discussion: https://community.m-files.com/forums-1552881334/f/m-files-api/7892/vaf-configuration-datetime-bug

Added unit test for fix.

Also added documentation on how to turn off configuration upgrading, if needed.