### PR TITLE
Added: IEnumerable<T>.EnsureNotNull() and EnvironmentBase.CurrentUserIsSystemProcess

### DIFF
--- a/MFiles.VAF.Extensions.Tests/ExtensionMethods/EnvironmentBaseExtensionMethodsTests.cs
+++ b/MFiles.VAF.Extensions.Tests/ExtensionMethods/EnvironmentBaseExtensionMethodsTests.cs
@@ -20,7 +20,7 @@ namespace MFiles.VAF.Extensions.Tests.ExtensionMethods
 		{
 			var environmentBase = new EnvironmentBase()
 			{
-				CurrentUserID = EnvironmentBaseExtensionMethods.MFilesServerUserID
+				CurrentUserID = MFBuiltInUsers.MFilesServerUserID
 			};
 			Assert.IsTrue(environmentBase.CurrentUserIsSystemProcess());
 		}

--- a/MFiles.VAF.Extensions.Tests/ExtensionMethods/EnvironmentBaseExtensionMethodsTests.cs
+++ b/MFiles.VAF.Extensions.Tests/ExtensionMethods/EnvironmentBaseExtensionMethodsTests.cs
@@ -10,29 +10,29 @@ namespace MFiles.VAF.Extensions.Tests.ExtensionMethods
 	{
 		[TestMethod]
 		[ExpectedException(typeof(ArgumentNullException))]
-		public void CurrentUserIsSystemProcess_ThrowsWithNullArgument()
+		public void IsCurrentUserSystemProcess_ThrowsWithNullArgument()
 		{
-			((EnvironmentBase)null).CurrentUserIsSystemProcess();
+			((EnvironmentBase)null).IsCurrentUserSystemProcess();
 		}
 
 		[TestMethod]
-		public void CurrentUserIsSystemProcess_ReturnsTrueForMFilesServerUser()
+		public void IsCurrentUserSystemProcess_ReturnsTrueForMFilesServerUser()
 		{
 			var environmentBase = new EnvironmentBase()
 			{
 				CurrentUserID = MFBuiltInUsers.MFilesServerUserID
 			};
-			Assert.IsTrue(environmentBase.CurrentUserIsSystemProcess());
+			Assert.IsTrue(environmentBase.IsCurrentUserSystemProcess());
 		}
 
 		[TestMethod]
-		public void CurrentUserIsSystemProcess_ReturnsFalseForRandomValidUserId()
+		public void IsCurrentUserSystemProcess_ReturnsFalseForRandomValidUserId()
 		{
 			var environmentBase = new EnvironmentBase()
 			{
 				CurrentUserID = 4 // chosen by fair dice roll; guaranteed to be random.
 			};
-			Assert.IsFalse(environmentBase.CurrentUserIsSystemProcess());
+			Assert.IsFalse(environmentBase.IsCurrentUserSystemProcess());
 		}
 	}
 }

--- a/MFiles.VAF.Extensions.Tests/ExtensionMethods/EnvironmentBaseExtensionMethodsTests.cs
+++ b/MFiles.VAF.Extensions.Tests/ExtensionMethods/EnvironmentBaseExtensionMethodsTests.cs
@@ -1,0 +1,38 @@
+﻿using MFiles.VAF.Common;
+using MFiles.VAF.Extensions.ExtensionMethods;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+
+namespace MFiles.VAF.Extensions.Tests.ExtensionMethods
+{
+	[TestClass]
+	public class EnvironmentBaseExtensionMethodsTests
+	{
+		[TestMethod]
+		[ExpectedException(typeof(ArgumentNullException))]
+		public void CurrentUserIsSystemProcess_ThrowsWithNullArgument()
+		{
+			((EnvironmentBase)null).CurrentUserIsSystemProcess();
+		}
+
+		[TestMethod]
+		public void CurrentUserIsSystemProcess_ReturnsTrueForMFilesServerUser()
+		{
+			var environmentBase = new EnvironmentBase()
+			{
+				CurrentUserID = EnvironmentBaseExtensionMethods.MFilesServerUserID
+			};
+			Assert.IsTrue(environmentBase.CurrentUserIsSystemProcess());
+		}
+
+		[TestMethod]
+		public void CurrentUserIsSystemProcess_ReturnsFalseForRandomValidUserId()
+		{
+			var environmentBase = new EnvironmentBase()
+			{
+				CurrentUserID = 4 // chosen by fair dice roll; guaranteed to be random.
+			};
+			Assert.IsFalse(environmentBase.CurrentUserIsSystemProcess());
+		}
+	}
+}

--- a/MFiles.VAF.Extensions.Tests/ExtensionMethods/IEnumerableExtensionMethodsTests.cs
+++ b/MFiles.VAF.Extensions.Tests/ExtensionMethods/IEnumerableExtensionMethodsTests.cs
@@ -1,0 +1,25 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace MFiles.VAF.Extensions.Tests.ExtensionMethods
+{
+	[TestClass]
+	public class IEnumerableExtensionMethodsTests
+	{
+		[TestMethod]
+		public void EnsureNotNull_ReturnsOriginalCollection()
+		{
+			var collection = new List<string>();
+			Assert.AreSame(collection, collection.EnsureNotNull());
+		}
+
+		[TestMethod]
+		public void EnsureNotNull_DoesNotReturnNull()
+		{
+			Assert.IsNotNull(((IEnumerable<string>)null).EnsureNotNull());
+		}
+	}
+}

--- a/MFiles.VAF.Extensions.Tests/ExtensionMethods/IEnumerableExtensionMethodsTests.cs
+++ b/MFiles.VAF.Extensions.Tests/ExtensionMethods/IEnumerableExtensionMethodsTests.cs
@@ -10,16 +10,16 @@ namespace MFiles.VAF.Extensions.Tests.ExtensionMethods
 	public class IEnumerableExtensionMethodsTests
 	{
 		[TestMethod]
-		public void EnsureNotNull_ReturnsOriginalCollection()
+		public void AsNotNull_ReturnsOriginalCollection()
 		{
 			var collection = new List<string>();
-			Assert.AreSame(collection, collection.EnsureNotNull());
+			Assert.AreSame(collection, collection.AsNotNull());
 		}
 
 		[TestMethod]
-		public void EnsureNotNull_DoesNotReturnNull()
+		public void AsNotNull_DoesNotReturnNull()
 		{
-			Assert.IsNotNull(((IEnumerable<string>)null).EnsureNotNull());
+			Assert.IsNotNull(((IEnumerable<string>)null).AsNotNull());
 		}
 	}
 }

--- a/MFiles.VAF.Extensions/ExtensionMethods/EnvironmentBaseExtensionMethods.cs
+++ b/MFiles.VAF.Extensions/ExtensionMethods/EnvironmentBaseExtensionMethods.cs
@@ -1,0 +1,25 @@
+﻿using MFiles.VAF.Common;
+using System;
+
+namespace MFiles.VAF.Extensions.ExtensionMethods
+{
+	public static class EnvironmentBaseExtensionMethods
+	{
+		/// <summary>
+		/// The user ID reported when code is run as the M-Files user
+		/// (e.g. automatic state transitions, task processing).
+		/// </summary>
+		internal const int MFilesServerUserID = -102;
+
+		/// <summary>
+		/// Returns true if <see cref="EnvironmentBase.CurrentUserID"/>
+		/// is set to a system process (i.e. an ID less than or equal to zero).
+		/// </summary>
+		/// <param name="env">The environment to check.</param>
+		/// <returns>true if <see cref="EnvironmentBase.CurrentUserID"/> is less than or equal to zero</returns>
+		/// <exception cref="ArgumentNullException">Thrown if <paramref name="env"/> is null.</exception>
+		public static bool CurrentUserIsSystemProcess(this EnvironmentBase env)
+			// IDs under zero are system processes.
+			=> (env ?? throw new ArgumentNullException(nameof(env))).CurrentUserID  <= 0;
+	}
+}

--- a/MFiles.VAF.Extensions/ExtensionMethods/EnvironmentBaseExtensionMethods.cs
+++ b/MFiles.VAF.Extensions/ExtensionMethods/EnvironmentBaseExtensionMethods.cs
@@ -6,12 +6,6 @@ namespace MFiles.VAF.Extensions.ExtensionMethods
 	public static class EnvironmentBaseExtensionMethods
 	{
 		/// <summary>
-		/// The user ID reported when code is run as the M-Files user
-		/// (e.g. automatic state transitions, task processing).
-		/// </summary>
-		internal const int MFilesServerUserID = -102;
-
-		/// <summary>
 		/// Returns true if <see cref="EnvironmentBase.CurrentUserID"/>
 		/// is set to a system process (i.e. an ID less than or equal to zero).
 		/// </summary>

--- a/MFiles.VAF.Extensions/ExtensionMethods/EnvironmentBaseExtensionMethods.cs
+++ b/MFiles.VAF.Extensions/ExtensionMethods/EnvironmentBaseExtensionMethods.cs
@@ -12,7 +12,7 @@ namespace MFiles.VAF.Extensions.ExtensionMethods
 		/// <param name="env">The environment to check.</param>
 		/// <returns>true if <see cref="EnvironmentBase.CurrentUserID"/> is less than or equal to zero</returns>
 		/// <exception cref="ArgumentNullException">Thrown if <paramref name="env"/> is null.</exception>
-		public static bool CurrentUserIsSystemProcess(this EnvironmentBase env)
+		public static bool IsCurrentUserSystemProcess(this EnvironmentBase env)
 			// IDs under zero are system processes.
 			=> (env ?? throw new ArgumentNullException(nameof(env))).CurrentUserID  <= 0;
 	}

--- a/MFiles.VAF.Extensions/ExtensionMethods/IEnumerableExtensionMethods.cs
+++ b/MFiles.VAF.Extensions/ExtensionMethods/IEnumerableExtensionMethods.cs
@@ -1,23 +1,38 @@
-﻿using MFiles.VAF.Configuration.Domain.Dashboards;
-using MFiles.VAF.Extensions.Dashboards;
-using MFilesAPI;
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace MFiles.VAF.Extensions
 {
 	public static partial class IEnumerableExtensionMethods
 	{
-		// From https://github.com/morelinq/MoreLINQ#distinctby
-		// If we need more then we should consider referencing MoreLinq directly.
+		/// <summary>
+		/// Returns all distinct elements of the given source, where "distinctness"
+		/// is determined via a projection and the default equality comparer for the projected type.
+		/// </summary>
+		/// <remarks>
+		/// This operator uses deferred execution and streams the results, although
+		/// a set of already-seen keys is retained. If a key is seen multiple times,
+		/// only the first element with that key is returned.
+		/// </remarks>
+		/// <typeparam name="TSource">Type of the source sequence</typeparam>
+		/// <typeparam name="TKey">Type of the projected element</typeparam>
+		/// <param name="source">Source sequence</param>
+		/// <param name="keySelector">Projection for determining "distinctness"</param>
+		/// <returns>A sequence consisting of distinct elements from the source sequence,
+		/// comparing them by the specified key projection.</returns>
+		/// <remarks>
+		/// From https://github.com/morelinq/MoreLINQ#distinctby
+		/// If we need more then we should consider referencing MoreLinq directly.
+		/// </remarks>
 		public static IEnumerable<TSource> DistinctBy<TSource, TKey>
-		(this IEnumerable<TSource> source, Func<TSource, TKey> keySelector)
+		(
+			this IEnumerable<TSource> source, 
+			Func<TSource, TKey> keySelector
+		)
 		{
 			HashSet<TKey> knownKeys = new HashSet<TKey>();
-			foreach (TSource element in source)
+			foreach (TSource element in source.EnsureNotNull())
 			{
 				if (knownKeys.Add(keySelector(element)))
 				{
@@ -25,5 +40,15 @@ namespace MFiles.VAF.Extensions
 				}
 			}
 		}
+
+		/// <summary>
+		/// Returns <paramref name="collection"/> or, if it is null,
+		/// <see cref="Enumerable.Empty{TResult}"/>.
+		/// </summary>
+		/// <typeparam name="T">The type of items in the collection.</typeparam>
+		/// <param name="collection">The collection.</param>
+		/// <returns><paramref name="collection"/> or, if it is null, <see cref="Enumerable.Empty{TResult}"/>.</returns>
+		public static IEnumerable<T> EnsureNotNull<T>(this IEnumerable<T> collection) 
+			=> collection ?? Enumerable.Empty<T>();
 	}
 }

--- a/MFiles.VAF.Extensions/ExtensionMethods/IEnumerableExtensionMethods.cs
+++ b/MFiles.VAF.Extensions/ExtensionMethods/IEnumerableExtensionMethods.cs
@@ -32,7 +32,7 @@ namespace MFiles.VAF.Extensions
 		)
 		{
 			HashSet<TKey> knownKeys = new HashSet<TKey>();
-			foreach (TSource element in source.EnsureNotNull())
+			foreach (TSource element in source.AsNotNull())
 			{
 				if (knownKeys.Add(keySelector(element)))
 				{
@@ -48,7 +48,7 @@ namespace MFiles.VAF.Extensions
 		/// <typeparam name="T">The type of items in the collection.</typeparam>
 		/// <param name="collection">The collection.</param>
 		/// <returns><paramref name="collection"/> or, if it is null, <see cref="Enumerable.Empty{TResult}"/>.</returns>
-		public static IEnumerable<T> EnsureNotNull<T>(this IEnumerable<T> collection) 
+		public static IEnumerable<T> AsNotNull<T>(this IEnumerable<T> collection) 
 			=> collection ?? Enumerable.Empty<T>();
 	}
 }

--- a/MFiles.VAF.Extensions/MFBuiltInUsers.cs
+++ b/MFiles.VAF.Extensions/MFBuiltInUsers.cs
@@ -1,0 +1,14 @@
+﻿namespace MFiles.VAF.Extensions
+{
+	/// <summary>
+	/// Internal class for enum-style access to "built-in" users.
+	/// </summary>
+	internal static class MFBuiltInUsers
+	{
+		/// <summary>
+		/// The user ID reported when code is run as the M-Files user
+		/// (e.g. automatic state transitions, task processing).
+		/// </summary>
+		internal const int MFilesServerUserID = -102;
+	}
+}


### PR DESCRIPTION
Added `IEnumerableExtensionMethods.EnsureNotNull()`.
Returns the collection passed (if not null), or returns Enumerable.Empty<T> if the collection is null.

Added `EnvironmentBase.CurrentUserIsSystemProcess()`
Returns true if the user ID is equal to or less than zero, or false if the user ID is a valid user ID.

Added unit tests for above.