### PR TITLE
Do not remove entries from serialization if type = MFIdentifier and AllowEmpty = false

### DIFF
--- a/MFiles.VAF.Extensions.Tests/Configuration/Upgrading/Rules/EnsureLatestSerializationSettingsUpgradeRuleTests.cs
+++ b/MFiles.VAF.Extensions.Tests/Configuration/Upgrading/Rules/EnsureLatestSerializationSettingsUpgradeRuleTests.cs
@@ -780,5 +780,36 @@ namespace MFiles.VAF.Extensions.Tests.Configuration.Upgrading.Rules
 				""NormalDate"" : ""2020-12-31T01:02:03""
 			}", rule.GetReadWriteLocationValue(vault));
 		}
+
+		[DataContract]
+		public sealed class PropertyDefSerialization
+		{
+			[DataMember]
+			[JsonConfEditor(IsRequired = false)]
+			[MFPropertyDef]
+			public MFIdentifier ReminderDate { get; set; } = "MF.PD.ReminderDate";
+
+			[DataMember]
+			[JsonConfEditor(IsRequired = false)]
+			[MFPropertyDef(AllowEmpty = true)]
+			public MFIdentifier NotificationDate { get; set; } = "MF.PD.NotificationDate";
+		}
+
+		[TestMethod]
+		public void VaultElementReference_Serialization()
+		{
+			var vault = Mock.Of<Vault>();
+			var rule = new EnsureLatestSerializationSettingsUpgradeRuleProxy<PropertyDefSerialization>();
+			rule.SetReadWriteLocation(MFNamedValueType.MFConfigurationValue, "sampleNamespace", "config");
+			rule.SetReadWriteLocationValue(vault, @"{
+				""ReminderDate"" : ""MF.PD.ReminderDate"",
+				""NotificationDate"" : ""MF.PD.NotificationDate""
+			}");
+
+			Assert.IsTrue(rule.Execute(vault));
+			Assert.That.AreEqualJson(@"{
+				""ReminderDate"" : ""MF.PD.ReminderDate""
+			}", rule.GetReadWriteLocationValue(vault));
+		}
 	}
 }

--- a/MFiles.VAF.Extensions/Configuration/Upgrading/JsonConversion/NewtonsoftJsonConvert.cs
+++ b/MFiles.VAF.Extensions/Configuration/Upgrading/JsonConversion/NewtonsoftJsonConvert.cs
@@ -165,6 +165,20 @@ namespace MFiles.VAF.Extensions
 						}
 					}
 
+					// If it's an MFIdentifier then force default values for non-allow-empty members.
+					{
+						if (type == typeof(MFIdentifier))
+						{
+							var vaultElementReferenceAttribute = this.memberInfo.GetCustomAttribute<VaultElementReferenceAttribute>();
+							if (null != vaultElementReferenceAttribute && !vaultElementReferenceAttribute.AllowEmpty)
+							{
+								// We have a value, but we're not allowed empty values.
+								// Return the value.
+								return value;
+							}
+						}
+					}
+
 					// If the data is the same as the default value then do not serialize.
 					if (type == typeof(string) && string.Equals(defaultValue, value))
 						return null;


### PR DESCRIPTION
Previous logic could remove default values that had been set explicitly.  This would then cause the validation to fail.

New logic may end up adding some default values to the JSON, but the validation now will not move from valid to invalid on vault restart.