### PR TITLE
Added order property and Ordered by it

### DIFF
--- a/MFiles.VAF.Extensions/Dashboards/AsynchronousDashboardContent/DashboardQueueAndTaskDetails.cs
+++ b/MFiles.VAF.Extensions/Dashboards/AsynchronousDashboardContent/DashboardQueueAndTaskDetails.cs
@@ -44,5 +44,10 @@ namespace MFiles.VAF.Extensions.Dashboards.AsynchronousDashboardContent
 		/// If this is a recurring process then details on the recurring frequency.
 		/// </summary>
 		public IRecurrenceConfiguration RecurrenceConfiguration { get; set; }
+
+		/// <summary>
+		/// Determines the order the operations are shown on the dashboard.
+		/// </summary>
+		public int Order { get; set; }
 	}
 }

--- a/MFiles.VAF.Extensions/Dashboards/AsynchronousDashboardContent/TaskManagerExAsynchronousDashboardContentProvider.cs
+++ b/MFiles.VAF.Extensions/Dashboards/AsynchronousDashboardContent/TaskManagerExAsynchronousDashboardContentProvider.cs
@@ -63,8 +63,12 @@ namespace MFiles.VAF.Extensions.Dashboards.AsynchronousDashboardContent
 		/// <inheritdoc />
 		public IEnumerable<KeyValuePair<DashboardQueueAndTaskDetails, IEnumerable<TaskInfo<TaskDirective>>>> GetAsynchronousDashboardContent()
 		{
+
+			var items = new List<KeyValuePair<DashboardQueueAndTaskDetails, IEnumerable<TaskInfo<TaskDirective>>>>();
+
 			if (null == TaskQueueResolver)
-				yield break;
+				return items;
+
 
 			foreach (var queue in TaskQueueResolver.GetQueues())
 			{
@@ -184,7 +188,7 @@ namespace MFiles.VAF.Extensions.Dashboards.AsynchronousDashboardContent
 						.TryGetValue(queue, processor.Type, out recurrenceConfiguration);
 
 					// Return the data.
-					yield return new KeyValuePair<DashboardQueueAndTaskDetails, IEnumerable<TaskInfo<TaskDirective>>>
+					items.Add(new KeyValuePair<DashboardQueueAndTaskDetails, IEnumerable<TaskInfo<TaskDirective>>>
 					(
 						new DashboardQueueAndTaskDetails()
 						{
@@ -194,16 +198,19 @@ namespace MFiles.VAF.Extensions.Dashboards.AsynchronousDashboardContent
 							Description = showOnDashboardAttribute?.Description,
 							Commands = commands,
 							TasksInQueue = waitingTasks,
+							Order = showOnDashboardAttribute?.Order ?? 100,
 							RecurrenceConfiguration = recurrenceConfiguration
 						},
 						// Get known executions (prior, running and future).
 						showDegraded
 							? TaskManager.GetExecutions<TaskDirective>(queue, processor.Type, MFTaskState.MFTaskStateInProgress)
 							: TaskManager.GetAllExecutions<TaskDirective>(queue, processor.Type)
-					);
+					));
 
 				}
 			}
+
+			return items.OrderBy(i => i.Key.Order);
 		}
 	}
 }

--- a/MFiles.VAF.Extensions/Dashboards/TaskQueues/ShowOnDashboardAttribute.cs
+++ b/MFiles.VAF.Extensions/Dashboards/TaskQueues/ShowOnDashboardAttribute.cs
@@ -97,6 +97,11 @@ namespace MFiles.VAF.Extensions.Dashboards
 		/// </summary>
 		public string RunCommandDisplayText { get; set; } = ShowOnDashboardAttribute.DefaultRunCommandDisplayText;
 
+		/// <summary>
+		/// Used to determine the order in which the task processors are shown on the dashboard
+		/// </summary>
+		public int Order { get; set; } = 100;
+
 		public ShowOnDashboardAttribute(string name)
 		{
 			this.Name = name;


### PR DESCRIPTION
Possible fix for #102.
Added a property "Order" to ShowOnDashboardAttribute and DashbardQueueAndTaskDetails and ordered by them instead of returning in "random" order.
Removed the yield return statements and switched to "normal" return statements.
Default Order set to 100.