### PR TITLE
Fix: SearchConditionJA.FileType was not persisted upon vault restart

### DIFF
--- a/MFiles.VAF.Extensions.Tests/Configuration/Upgrading/Rules/EnsureLatestSerializationSettingsUpgradeRuleTests.cs
+++ b/MFiles.VAF.Extensions.Tests/Configuration/Upgrading/Rules/EnsureLatestSerializationSettingsUpgradeRuleTests.cs
@@ -659,7 +659,8 @@ namespace MFiles.VAF.Extensions.Tests.Configuration.Upgrading.Rules
             ""conditionType"": ""equal"",
             ""expression"": {
                 ""type"": ""propertyValue"",
-                ""propertyDef"": ""{82490C2F-8FB2-423B-85B5-F4ADB214C0FD}""
+                ""propertyDef"": ""{82490C2F-8FB2-423B-85B5-F4ADB214C0FD}"",
+				""indirectionLevels"": []
             },
             ""typedValue"": {
                 ""dataType"": ""lookup"",
@@ -672,7 +673,54 @@ namespace MFiles.VAF.Extensions.Tests.Configuration.Upgrading.Rules
 }", rule.GetReadWriteLocationValue(vault));
 
 		}
-    
+
+		[TestMethod]
+		public void ConfigurationWithSearchConditionsJA_FileTypeSearch()
+		{
+			var vault = Mock.Of<Vault>();
+			var rule = new EnsureLatestSerializationSettingsUpgradeRuleProxy<ConfigurationWithSearchConditionsJA>();
+			rule.SetReadWriteLocation(MFNamedValueType.MFConfigurationValue, "sampleNamespace", "config");
+			rule.SetReadWriteLocationValue(vault, @"{
+    ""SearchConditions"": [
+                {
+                    ""conditionType"": ""equal"",
+                    ""expression"": {
+                        ""type"": ""fileValue"",
+                        ""fileType"": ""hasFiles"",
+                        ""indirectionLevels"": []
+                    },
+                    ""typedValue"": {
+                        ""dataType"": ""boolean"",
+                        ""value"": {
+                            ""boolean"": false
+                        }
+                    }
+                }
+            ]
+}");
+
+			Assert.IsTrue(rule.Execute(vault));
+			Assert.That.AreEqualJson(@"{
+    ""SearchConditions"": [
+                {
+                    ""conditionType"": ""equal"",
+                    ""expression"": {
+                        ""type"": ""fileValue"",
+                        ""fileType"": ""hasFiles"",
+                        ""indirectionLevels"": []
+                    },
+                    ""typedValue"": {
+                        ""dataType"": ""boolean"",
+                        ""value"": {
+                            ""boolean"": false
+                        }
+                    }
+                }
+            ]
+}", rule.GetReadWriteLocationValue(vault));
+
+		}
+
 		#region IStableValueOptionsProvider
 
 		// Using this approach always stored enum values as integers; ensure we respect that.

--- a/MFiles.VAF.Extensions/Configuration/Upgrading/JsonConversion/JsonConvert.cs
+++ b/MFiles.VAF.Extensions/Configuration/Upgrading/JsonConversion/JsonConvert.cs
@@ -19,10 +19,18 @@ namespace MFiles.VAF.Extensions
 		public abstract string Serialize(object input, Type t);
 
 		/// <summary>
-		/// If these types are found then their default values are left intact
-		/// when converting the JSON.
+		/// If these types are found then their default values output when serializing
+		/// instances.
 		/// </summary>
-		public static List<string> DefaultValueSkippedTypes { get; } = new List<string>()
+		/// <remarks></remarks>
+		public static List<string> DefaultValueSkippedTypes { get; } = new List<string>();
+
+		/// <summary>
+		/// If these types are found in the JSON then the raw JSON will be maintained.
+		/// Useful for types that are not expected to go through .NET serialization
+		/// such as <see cref="VAF.Configuration.JsonAdaptor.SearchConditionsJA"/>.
+		/// </summary>
+		public static List<string> LeaveJsonAloneTypes { get; } = new List<string>()
 		{
 			"MFiles.VAF.Configuration.JsonAdaptor.SearchConditionsJA"
 		};

--- a/MFiles.VAF.Extensions/Configuration/Upgrading/JsonConversion/JsonConvert.cs
+++ b/MFiles.VAF.Extensions/Configuration/Upgrading/JsonConversion/JsonConvert.cs
@@ -24,7 +24,8 @@ namespace MFiles.VAF.Extensions
 		/// </summary>
 		public static List<string> DefaultValueSkippedTypes { get; } = new List<string>()
 		{
-			"MFiles.VAF.Configuration.JsonAdaptor.JsonValueAdaptor"
+			"MFiles.VAF.Configuration.JsonAdaptor.TypedValueJA",
+			"MFiles.VAF.Configuration.JsonAdaptor.ExpressionJA"
 		};
 	}
 }

--- a/MFiles.VAF.Extensions/Configuration/Upgrading/JsonConversion/JsonConvert.cs
+++ b/MFiles.VAF.Extensions/Configuration/Upgrading/JsonConversion/JsonConvert.cs
@@ -24,8 +24,7 @@ namespace MFiles.VAF.Extensions
 		/// </summary>
 		public static List<string> DefaultValueSkippedTypes { get; } = new List<string>()
 		{
-			"MFiles.VAF.Configuration.JsonAdaptor.TypedValueJA",
-			"MFiles.VAF.Configuration.JsonAdaptor.ExpressionJA"
+			"MFiles.VAF.Configuration.JsonAdaptor.SearchConditionsJA"
 		};
 	}
 }

--- a/MFiles.VAF.Extensions/Configuration/Upgrading/JsonConversion/NewtonsoftJsonConvert.cs
+++ b/MFiles.VAF.Extensions/Configuration/Upgrading/JsonConversion/NewtonsoftJsonConvert.cs
@@ -299,7 +299,13 @@ namespace MFiles.VAF.Extensions
 			}
 		}
 
-
+		/// <summary>
+		/// A converter that allows JSON for known types (<see cref="JsonConvert.LeaveJsonAloneTypes"/>)
+		/// to be round-tripped through deserialization/serialization, rather than the deserialization/serialization
+		/// process potentially affecting them.
+		/// Used to ensure that classes that cannot be deserialized/serialized in .NET
+		/// (such as <see cref="SearchConditionsJA"/>) are not changed.
+		/// </summary>
 		internal class LeaveJsonAloneConverter
 			: JsonConverterBase
 		{


### PR DESCRIPTION
Issue:
Some parts of SearchConditionsJA do not support going through serialization/deserialization to .NET types.  When the Extensions upgrade logic ran (which causes a serialization/deserialization), some corruption of the configuration could occur.

Impact:
When a vault was brought online, some parts of SearchConditionsJA were not correctly persisted, leading to odd errors or runtime issues.

Solution:
Added a JsonConverter which caches the raw incoming JSON of these nodes to ensure that they are written verbatim back to the resulting JSON.  Types that need to be handled this way can be added to MFiles.VAF.Extensions.JsonConvert.LeaveJsonAloneTypes.

No code changes are needed by external developers to take this fix into practice.