### PR TITLE
Always unescaping the layout string that the comparison works

### DIFF
--- a/MFiles.VAF.Extensions/Dashboards/Commands/ShowLatestLogEntriesDashboardCommand.cs
+++ b/MFiles.VAF.Extensions/Dashboards/Commands/ShowLatestLogEntriesDashboardCommand.cs
@@ -195,7 +195,7 @@ namespace MFiles.VAF.Extensions.Dashboards.Commands
 
 						// If it is not using the default layout then we can't parse it.
 						if (false == string.IsNullOrEmpty(defaultLoggingConfiguration?.Advanced?.Layout)
-							&& defaultLoggingConfiguration?.Advanced?.Layout != "${longdate}\t(v${application-version})\t${logger}\t${log-context}\t${level}:\t${message}${onexception:${newline}${exception:format=ToString:innerformat=ToString:separator=\r\n}}")
+							&& Regex.Unescape(defaultLoggingConfiguration?.Advanced?.Layout) != "${longdate}\t(v${application-version})\t${logger}\t${log-context}\t${level}:\t${message}${onexception:${newline}${exception:format=ToString:innerformat=ToString:separator=\r\n}}")
 							logEntries.StructuredEntries = false;
 					}
 					var linesRead = 0;


### PR DESCRIPTION
With the newer MFiles.VAF.Configuration.Logging.NLog (>23.2.14), the layout string is escaped. With earlier versions, the layout string is unescaped.

The fix always tries to escape the layout string. This works with both of the string types (escaped and unescaped) and therefore there isn't any version restrictions introduced with the fix.

Fixes  #114