### PR TITLE
Configuration upgrading is now disabled by default and available for opt-in

### DIFF
--- a/MFiles.VAF.Extensions.Tests/Configuration/Upgrading/ConfigurationUpgradeManager.TryGetDeclaredConfigurationUpgrades.UpgradesOnNewest.cs
+++ b/MFiles.VAF.Extensions.Tests/Configuration/Upgrading/ConfigurationUpgradeManager.TryGetDeclaredConfigurationUpgrades.UpgradesOnNewest.cs
@@ -18,7 +18,7 @@ namespace MFiles.VAF.Extensions.Tests.Configuration.Upgrading
 		[TestMethod]
 		public void TryGetDeclaredConfigurationUpgrades_UpgradeMethodOnNewest_NoUpgradePathsDefined()
 		{
-			var c = new VAF.Extensions.Configuration.Upgrading.ConfigurationUpgradeManager(Mock.Of<VaultApplicationBase>());
+			var c = new VAF.Extensions.Configuration.Upgrading.DefaultConfigurationUpgradeManager(Mock.Of<VaultApplicationBase>());
 			Assert.AreEqual(false, c.TryGetDeclaredConfigurationUpgrades<VersionZero>(out var configurationVersion, out var rules));
 			Assert.AreEqual("0.0", configurationVersion?.ToString());
 			Assert.AreEqual(0, rules.Count());
@@ -27,7 +27,7 @@ namespace MFiles.VAF.Extensions.Tests.Configuration.Upgrading
 		[TestMethod]
 		public void TryGetDeclaredConfigurationUpgrades_UpgradeMethodOnNewest_ZeroToOneUpgradeWithInstanceUpgradePath()
 		{
-			var c = new VAF.Extensions.Configuration.Upgrading.ConfigurationUpgradeManager(Mock.Of<VaultApplicationBase>());
+			var c = new VAF.Extensions.Configuration.Upgrading.DefaultConfigurationUpgradeManager(Mock.Of<VaultApplicationBase>());
 			Assert.AreEqual(true, c.TryGetDeclaredConfigurationUpgrades<VersionOneWithInstanceUpgradePath>(out var configurationVersion, out var rules));
 			Assert.AreEqual("1.0", configurationVersion?.ToString());
 			Assert.AreEqual(1, rules.Count());
@@ -38,7 +38,7 @@ namespace MFiles.VAF.Extensions.Tests.Configuration.Upgrading
 		[TestMethod]
 		public void TryGetDeclaredConfigurationUpgrades_UpgradeMethodOnNewest_ZeroToOneUpgradeWithInstanceUpgradePath_WithoutConfigurationAttribute()
 		{
-			var c = new VAF.Extensions.Configuration.Upgrading.ConfigurationUpgradeManager(Mock.Of<VaultApplicationBase>());
+			var c = new VAF.Extensions.Configuration.Upgrading.DefaultConfigurationUpgradeManager(Mock.Of<VaultApplicationBase>());
 			Assert.AreEqual(true, c.TryGetDeclaredConfigurationUpgrades<VersionOneWithoutConfigurationAttributeInstanceUpgradePath>(out var configurationVersion, out var rules));
 			Assert.AreEqual("1.0", configurationVersion?.ToString());
 			Assert.AreEqual(1, rules.Count());
@@ -50,7 +50,7 @@ namespace MFiles.VAF.Extensions.Tests.Configuration.Upgrading
 		[TestMethod]
 		public void TryGetDeclaredConfigurationUpgrades_UpgradeMethodOnNewest_ZeroToOneWithStaticUpgradePath()
 		{
-			var c = new VAF.Extensions.Configuration.Upgrading.ConfigurationUpgradeManager(Mock.Of<VaultApplicationBase>());
+			var c = new VAF.Extensions.Configuration.Upgrading.DefaultConfigurationUpgradeManager(Mock.Of<VaultApplicationBase>());
 			Assert.AreEqual(true, c.TryGetDeclaredConfigurationUpgrades<VersionOneWithStaticUpgradePath>(out var configurationVersion, out var rules));
 			Assert.AreEqual("1.0", configurationVersion?.ToString());
 			Assert.AreEqual(1, rules.Count());
@@ -61,7 +61,7 @@ namespace MFiles.VAF.Extensions.Tests.Configuration.Upgrading
 		[TestMethod]
 		public void TryGetDeclaredConfigurationUpgrades_UpgradeMethodOnNewest_OneToTwoWithStaticUpgradePath_WithJsonParameter()
 		{
-			var c = new VAF.Extensions.Configuration.Upgrading.ConfigurationUpgradeManager(Mock.Of<VaultApplicationBase>());
+			var c = new VAF.Extensions.Configuration.Upgrading.DefaultConfigurationUpgradeManager(Mock.Of<VaultApplicationBase>());
 			Assert.AreEqual(true, c.TryGetDeclaredConfigurationUpgrades<VersionTwoWithStaticUpgradePath>(out var configurationVersion, out var rules));
 			Assert.AreEqual("2.0", configurationVersion?.ToString());
 			Assert.AreEqual(2, rules.Count());
@@ -74,7 +74,7 @@ namespace MFiles.VAF.Extensions.Tests.Configuration.Upgrading
 		[TestMethod]
 		public void TryGetDeclaredConfigurationUpgrades_UpgradeMethodOnNewest_ZeroToTwoUpgradeWithInstanceUpgradePath()
 		{
-			var c = new VAF.Extensions.Configuration.Upgrading.ConfigurationUpgradeManager(Mock.Of<VaultApplicationBase>());
+			var c = new VAF.Extensions.Configuration.Upgrading.DefaultConfigurationUpgradeManager(Mock.Of<VaultApplicationBase>());
 			Assert.AreEqual(true, c.TryGetDeclaredConfigurationUpgrades<VersionTwoWithInstanceUpgradePath>(out var configurationVersion, out var rules));
 			Assert.AreEqual("2.0", configurationVersion?.ToString());
 			Assert.AreEqual(2, rules.Count());
@@ -87,7 +87,7 @@ namespace MFiles.VAF.Extensions.Tests.Configuration.Upgrading
 		[TestMethod]
 		public void TryGetDeclaredConfigurationUpgrades_UpgradeMethodOnNewest_ZeroToThreeUpgradeWithInstanceUpgradePath()
 		{
-			var c = new VAF.Extensions.Configuration.Upgrading.ConfigurationUpgradeManager(Mock.Of<VaultApplicationBase>());
+			var c = new VAF.Extensions.Configuration.Upgrading.DefaultConfigurationUpgradeManager(Mock.Of<VaultApplicationBase>());
 			Assert.AreEqual(true, c.TryGetDeclaredConfigurationUpgrades<VersionThreeWithInstanceUpgradePath>(out var configurationVersion, out var rules));
 			Assert.AreEqual("3.0", configurationVersion?.ToString());
 			Assert.AreEqual(3, rules.Count());
@@ -104,7 +104,7 @@ namespace MFiles.VAF.Extensions.Tests.Configuration.Upgrading
 		[TestMethod]
 		public void TryGetDeclaredConfigurationUpgrades_UpgradeMethodOnNewest_ThreeToFourUpgradeWithInstanceUpgradePath_WithJsonParameter()
 		{
-			var c = new VAF.Extensions.Configuration.Upgrading.ConfigurationUpgradeManager(Mock.Of<VaultApplicationBase>());
+			var c = new VAF.Extensions.Configuration.Upgrading.DefaultConfigurationUpgradeManager(Mock.Of<VaultApplicationBase>());
 			Assert.AreEqual(true, c.TryGetDeclaredConfigurationUpgrades<VersionFourWithInstanceUpgradePath>(out var configurationVersion, out var rules));
 			Assert.AreEqual("4.0", configurationVersion?.ToString());
 			Assert.AreEqual(4, rules.Count());
@@ -122,7 +122,7 @@ namespace MFiles.VAF.Extensions.Tests.Configuration.Upgrading
 		[TestMethod]
 		public void TryGetDeclaredConfigurationUpgrades_UpgradeMethodOnNewest_FourToFiveUpgradeWithInstanceUpgradePath()
 		{
-			var c = new VAF.Extensions.Configuration.Upgrading.ConfigurationUpgradeManager(Mock.Of<VaultApplicationBase>());
+			var c = new VAF.Extensions.Configuration.Upgrading.DefaultConfigurationUpgradeManager(Mock.Of<VaultApplicationBase>());
 			Assert.AreEqual(true, c.TryGetDeclaredConfigurationUpgrades<VersionFiveWithInstanceUpgradePath>(out var configurationVersion, out var rules));
 			Assert.AreEqual("5.0", configurationVersion?.ToString());
 			Assert.AreEqual(5, rules.Count());
@@ -142,7 +142,7 @@ namespace MFiles.VAF.Extensions.Tests.Configuration.Upgrading
 		[TestMethod]
 		public void TryGetDeclaredConfigurationUpgrades_UpgradeMethodOnNewest_FiveToSixUpgradeWithInstanceUpgradePath()
 		{
-			var c = new VAF.Extensions.Configuration.Upgrading.ConfigurationUpgradeManager(Mock.Of<VaultApplicationBase>());
+			var c = new VAF.Extensions.Configuration.Upgrading.DefaultConfigurationUpgradeManager(Mock.Of<VaultApplicationBase>());
 			Assert.AreEqual(true, c.TryGetDeclaredConfigurationUpgrades<VersionSixWithInstanceUpgradePath>(out var configurationVersion, out var rules));
 			Assert.AreEqual("6.0", configurationVersion?.ToString());
 			Assert.AreEqual(6, rules.Count());
@@ -167,7 +167,7 @@ namespace MFiles.VAF.Extensions.Tests.Configuration.Upgrading
 		[TestMethod]
 		public void TryGetDeclaredConfigurationUpgrades_UpgradeMethodOnNewest_CyclicUpgradeRule()
 		{
-			var c = new VAF.Extensions.Configuration.Upgrading.ConfigurationUpgradeManager(Mock.Of<VaultApplicationBase>());
+			var c = new VAF.Extensions.Configuration.Upgrading.DefaultConfigurationUpgradeManager(Mock.Of<VaultApplicationBase>());
 			Assert.AreEqual(false, c.TryGetDeclaredConfigurationUpgrades<CyclicUpgradeRule2>(out var configurationVersion, out var rules));
 		}
 

--- a/MFiles.VAF.Extensions.Tests/Configuration/Upgrading/ConfigurationUpgradeManager.TryGetDeclaredConfigurationUpgrades.UpgradesOnOldest.cs
+++ b/MFiles.VAF.Extensions.Tests/Configuration/Upgrading/ConfigurationUpgradeManager.TryGetDeclaredConfigurationUpgrades.UpgradesOnOldest.cs
@@ -22,7 +22,7 @@ namespace MFiles.VAF.Extensions.Tests.Configuration.Upgrading
 		[TestMethod]
 		public void TryGetDeclaredConfigurationUpgrades_UpgradeMethodOnOldest_AllUpgradePathsIdentified()
 		{
-			var c = new VAF.Extensions.Configuration.Upgrading.ConfigurationUpgradeManager(Mock.Of<VaultApplicationBase>());
+			var c = new VAF.Extensions.Configuration.Upgrading.DefaultConfigurationUpgradeManager(Mock.Of<VaultApplicationBase>());
 			Assert.AreEqual(true, c.TryGetDeclaredConfigurationUpgrades<VersionThreeWithStaticUpgradePath>(out var configurationVersion, out var rules));
 			Assert.AreEqual("3.0", configurationVersion?.ToString());
 			Assert.AreEqual(3, rules.Count());
@@ -37,14 +37,14 @@ namespace MFiles.VAF.Extensions.Tests.Configuration.Upgrading
 		[TestMethod]
 		public void TryGetDeclaredConfigurationUpgrades_UpgradeMethodOnOldest_CyclicUpgradeRule()
 		{
-			var c = new VAF.Extensions.Configuration.Upgrading.ConfigurationUpgradeManager(Mock.Of<VaultApplicationBase>());
+			var c = new VAF.Extensions.Configuration.Upgrading.DefaultConfigurationUpgradeManager(Mock.Of<VaultApplicationBase>());
 			Assert.AreEqual(false, c.TryGetDeclaredConfigurationUpgrades<CyclicUpgradeRule2>(out var configurationVersion, out var rules));
 		}
 
 		[TestMethod]
 		public void TryGetDeclaredConfigurationUpgrades_UpgradeMethodOnOldest_CyclicUpgradeRule_Same()
 		{
-			var c = new VAF.Extensions.Configuration.Upgrading.ConfigurationUpgradeManager(Mock.Of<VaultApplicationBase>());
+			var c = new VAF.Extensions.Configuration.Upgrading.DefaultConfigurationUpgradeManager(Mock.Of<VaultApplicationBase>());
 			Assert.AreEqual(false, c.TryGetDeclaredConfigurationUpgrades<CyclicUpgradeRule_Same>(out var configurationVersion, out var rules));
 		}
 
@@ -55,7 +55,7 @@ namespace MFiles.VAF.Extensions.Tests.Configuration.Upgrading
 		[TestMethod]
 		public void TryGetDeclaredConfigurationUpgrades_UpgradeMethodOnOldest_IdentifiesStringParameterMethod()
 		{
-			var c = new VAF.Extensions.Configuration.Upgrading.ConfigurationUpgradeManager(Mock.Of<VaultApplicationBase>());
+			var c = new VAF.Extensions.Configuration.Upgrading.DefaultConfigurationUpgradeManager(Mock.Of<VaultApplicationBase>());
 			Assert.AreEqual(true, c.TryGetDeclaredConfigurationUpgrades<VersionFourWithStaticUpgradePath>(out var configurationVersion, out var rules));
 			Assert.AreEqual("4.0", configurationVersion?.ToString());
 			Assert.AreEqual(4, rules.Count());
@@ -76,7 +76,7 @@ namespace MFiles.VAF.Extensions.Tests.Configuration.Upgrading
 		[TestMethod]
 		public void TryGetDeclaredConfigurationUpgrades_UpgradeMethodOnOldest_IdentifiesJObjectParameterMethod()
 		{
-			var c = new VAF.Extensions.Configuration.Upgrading.ConfigurationUpgradeManager(Mock.Of<VaultApplicationBase>());
+			var c = new VAF.Extensions.Configuration.Upgrading.DefaultConfigurationUpgradeManager(Mock.Of<VaultApplicationBase>());
 			Assert.AreEqual(true, c.TryGetDeclaredConfigurationUpgrades<VersionFiveWithStaticUpgradePath>(out var configurationVersion, out var rules));
 			Assert.AreEqual("5.0", configurationVersion?.ToString());
 			Assert.AreEqual(5, rules.Count());

--- a/MFiles.VAF.Extensions.Tests/Configuration/Upgrading/ConfigurationUpgradeManager.UpgradeConfiguration.cs
+++ b/MFiles.VAF.Extensions.Tests/Configuration/Upgrading/ConfigurationUpgradeManager.UpgradeConfiguration.cs
@@ -83,7 +83,7 @@ namespace MFiles.VAF.Extensions.Tests.Configuration.Upgrading
 		{
 			var vault = this.GetVaultMock().Object;
 			var managerMock = this.GetNamedValueStorageManagerMock();
-			var c = new Extensions.Configuration.Upgrading.ConfigurationUpgradeManager(Mock.Of<VaultApplicationBase>())
+			var c = new Extensions.Configuration.Upgrading.DefaultConfigurationUpgradeManager(Mock.Of<VaultApplicationBase>())
 			{
 				NamedValueStorageManager = managerMock.Object
 			};
@@ -106,7 +106,7 @@ namespace MFiles.VAF.Extensions.Tests.Configuration.Upgrading
 				"Castle.Proxies.VaultApplicationBaseProxy",
 				this.CreateNamedValues("config", Newtonsoft.Json.JsonConvert.SerializeObject(source))
 			);
-			var c = new Extensions.Configuration.Upgrading.ConfigurationUpgradeManager(Mock.Of<VaultApplicationBase>())
+			var c = new Extensions.Configuration.Upgrading.DefaultConfigurationUpgradeManager(Mock.Of<VaultApplicationBase>())
 			{
 				NamedValueStorageManager = managerMock.Object
 			};
@@ -136,7 +136,7 @@ namespace MFiles.VAF.Extensions.Tests.Configuration.Upgrading
 				"Castle.Proxies.VaultApplicationBaseProxy",
 				this.CreateNamedValues("configuration", @"{ ""World"" : ""abc"", ""Version"" : ""3.0"", ""TimeSpan"" : { ""Interval"" : ""01:02:03"", ""RunOnVaultStartup"" : false } }")
 			);
-			var c = new Extensions.Configuration.Upgrading.ConfigurationUpgradeManager(Mock.Of<VaultApplicationBase>())
+			var c = new Extensions.Configuration.Upgrading.DefaultConfigurationUpgradeManager(Mock.Of<VaultApplicationBase>())
 			{
 				NamedValueStorageManager = managerMock.Object
 			};
@@ -166,7 +166,7 @@ namespace MFiles.VAF.Extensions.Tests.Configuration.Upgrading
 				"Castle.Proxies.VaultApplicationBaseProxy",
 				this.CreateNamedValues("configuration", @"{ ""Version"" : ""3.0"", ""TimeSpan"" : { ""Interval"" : ""01:02:03"", ""RunOnVaultStartup"" : false }, ""TimeSpan-Comment"": ""hello world"" }")
 			);
-			var c = new Extensions.Configuration.Upgrading.ConfigurationUpgradeManager(Mock.Of<VaultApplicationBase>())
+			var c = new Extensions.Configuration.Upgrading.DefaultConfigurationUpgradeManager(Mock.Of<VaultApplicationBase>())
 			{
 				NamedValueStorageManager = managerMock.Object
 			};

--- a/MFiles.VAF.Extensions/ConfigurableVaultApplicationBase.ConfigurationUpgrading.cs
+++ b/MFiles.VAF.Extensions/ConfigurableVaultApplicationBase.ConfigurationUpgrading.cs
@@ -24,11 +24,13 @@ namespace MFiles.VAF.Extensions
 		/// Returns the instance of <see cref="IConfigurationUpgradeManager"/> that will be used
 		/// to upgrade any configuration found.
 		/// </summary>
-		/// <returns></returns>
+		/// <returns>
+		/// <see langword="null"/> by default.  
+		/// Return an instance of something that inherits <see cref="IConfigurationUpgradeManager"/>,
+		/// for example <see cref="DefaultConfigurationUpgradeManager"/>, to control configuration upgrading.
+		/// </returns>
 		public virtual IConfigurationUpgradeManager GetConfigurationUpgradeManager()
-		{
-			return new ConfigurationUpgradeManager(this);
-		}
+			=> null;
 
 		/// <inheritdoc />
 		/// <remarks>Will call <see cref="UpgradeConfiguration"/> then call the base implementation.</remarks>

--- a/MFiles.VAF.Extensions/Configuration/Upgrading/DefaultConfigurationUpgradeManager.cs
+++ b/MFiles.VAF.Extensions/Configuration/Upgrading/DefaultConfigurationUpgradeManager.cs
@@ -13,10 +13,10 @@ using System.Reflection;
 
 namespace MFiles.VAF.Extensions.Configuration.Upgrading
 {
-	public class ConfigurationUpgradeManager
+	public class DefaultConfigurationUpgradeManager
 		: IConfigurationUpgradeManager
 	{
-		private ILogger Logger { get; } = LogManager.GetLogger(typeof(ConfigurationUpgradeManager));
+		private ILogger Logger { get; } = LogManager.GetLogger(typeof(DefaultConfigurationUpgradeManager));
 
 		/// <summary>
 		/// The NamedValueStorageManager used to interact with named value storage.
@@ -34,7 +34,7 @@ namespace MFiles.VAF.Extensions.Configuration.Upgrading
 		/// </summary>
 		protected VaultApplicationBase VaultApplication { get; set; } 
 
-		public ConfigurationUpgradeManager(VaultApplicationBase vaultApplication)
+		public DefaultConfigurationUpgradeManager(VaultApplicationBase vaultApplication)
 		{
 			this.VaultApplication = vaultApplication ?? throw new ArgumentNullException(nameof(vaultApplication));
 		}

--- a/MFiles.VAF.Extensions/Configuration/Upgrading/Readme.md
+++ b/MFiles.VAF.Extensions/Configuration/Upgrading/Readme.md
@@ -4,6 +4,19 @@ When using the `ConfigurableVaultApplicationBase<T>` class, changes to the struc
 
 This library supports the ability for you to programmatically control the upgrade process so that the application can convert any old configuration across to the new structures and continue loading.
 
+## Enabling the functionality
+
+Within your VaultApplication class, override `GetConfigurationUpgradeManager` and return an instance of something that implements `IConfigurationUpgradeManager`. The default implementation is within `DefaultConfigurationUpgradeManager`:
+
+```csharp
+public override IConfigurationUpgradeManager GetConfigurationUpgradeManager()
+{
+	return new DefaultConfigurationUpgradeManager(this);
+}
+```
+
+The configuration upgrade process will now run whenever the vault comes online.
+
 ## Adding versioning to your configuration class
 
 Consider that we wish to make a change to the configuration structure but wish to be able to migrate the old configuration across.  Consider these configuration classes:

--- a/MFiles.VAF.Extensions/ExtensionMethods/TypeExtensionMethods.cs
+++ b/MFiles.VAF.Extensions/ExtensionMethods/TypeExtensionMethods.cs
@@ -258,7 +258,7 @@ namespace MFiles.VAF.Extensions
 		/// </summary>
 		/// <param name="configurationType">The configuration type to check.</param>
 		/// <param name="vaultApplication">The vault application to fall back to.</param>
-		/// <param name="configurationVersion">The version of the configuration, or <see cref="ConfigurationUpgradeManager.VersionZero"/> if none is available.</param>
+		/// <param name="configurationVersion">The version of the configuration, or <see cref="DefaultConfigurationUpgradeManager.VersionZero"/> if none is available.</param>
 		/// <returns>The location in named value storage.</returns>
 		/// <exception cref="ArgumentNullException">If <paramref name="configurationType"/> or <paramref name="vaultApplication"/> are null.</exception>
 		public static ISingleNamedValueItem GetConfigurationLocation(this Type configurationType, VaultApplicationBase vaultApplication, out Version configurationVersion)
@@ -274,7 +274,7 @@ namespace MFiles.VAF.Extensions
 						.Where(a => a is Configuration.ConfigurationVersionAttribute)
 						.Cast<Configuration.ConfigurationVersionAttribute>()
 						.FirstOrDefault();
-			configurationVersion = parameterTypeConfigurationVersionAttribute?.Version ?? ConfigurationUpgradeManager.VersionZero;
+			configurationVersion = parameterTypeConfigurationVersionAttribute?.Version ?? DefaultConfigurationUpgradeManager.VersionZero;
 
 			// Where should we read from? (Use the configuration attribute if we can, otherwise default to vault application location.
 			return (parameterTypeConfigurationVersionAttribute?.UsesCustomNVSLocation ?? false)


### PR DESCRIPTION
Configuration upgrading has some known and unavoidable side-effects, including removal of default values within the stored JSON.  This occasionally causes confusion.

Altered implementation to disable the configuration upgrading functionality unless someone opts-in to it.  Future changes may go further, including possibly splitting this implementation out to a separate library.