### PR TITLE
TimeZoneInformationExtensionMethods: Utc method should return the Utc DateTimeKind

### DIFF
--- a/MFiles.VAF.Extensions.Tests/ExtensionMethods/TimeZoneInformationExtensionMethodsTests.cs
+++ b/MFiles.VAF.Extensions.Tests/ExtensionMethods/TimeZoneInformationExtensionMethodsTests.cs
@@ -23,14 +23,7 @@ namespace MFiles.VAF.Extensions.Tests.ExtensionMethods
 
 			var output = tzMock.Object.EnsureLocalTime(input);
 			Assert.AreEqual(expected.ToString(), output.ToString());
-			Assert.AreEqual
-			(
-				expected.Kind, 
-				input.Kind == DateTimeKind.Unspecified
-					? DateTimeKind.Unspecified
-					: DateTimeKind.Local
-			);
-
+			Assert.AreEqual(expected.Kind, output.Kind);
 		}
 
 		public static IEnumerable<object[]> GetEnsureLocalTimeData()
@@ -69,14 +62,7 @@ namespace MFiles.VAF.Extensions.Tests.ExtensionMethods
 
 			var output = tzMock.Object.EnsureUTCTime(input);
 			Assert.AreEqual(expected.ToString(), output.ToString());
-			Assert.AreEqual
-			(
-				expected.Kind,
-				input.Kind == DateTimeKind.Unspecified
-					? DateTimeKind.Unspecified
-					: DateTimeKind.Utc
-			);
-
+			Assert.AreEqual(expected.Kind, output.Kind);
 		}
 
 		public static IEnumerable<object[]> GetEnsureUtcTimeData()

--- a/MFiles.VAF.Extensions/ExtensionMethods/TimeZoneInformationExtensionMethods.cs
+++ b/MFiles.VAF.Extensions/ExtensionMethods/TimeZoneInformationExtensionMethods.cs
@@ -98,7 +98,7 @@ namespace MFiles.VAF.Extensions
 			{
 				TimeZoneInfo tzi = TimeZoneInfo.FindSystemTimeZoneById(timeZoneInfo.StandardName);
 				var output = input.Subtract(tzi.GetUtcOffset(input));
-				return DateTime.SpecifyKind(output, DateTimeKind.Local);
+				return DateTime.SpecifyKind(output, DateTimeKind.Utc);
 			}
 			catch (Exception ex)
 			{


### PR DESCRIPTION
Utc method should return the Utc DateTimeKind. Updated unit tests to properly compare expected and output.