### PR TITLE
Fix for issue 134

### DIFF
--- a/MFiles.VAF.Extensions.Tests/Configuration/MetadataStructureValidatorTests.cs
+++ b/MFiles.VAF.Extensions.Tests/Configuration/MetadataStructureValidatorTests.cs
@@ -211,6 +211,9 @@ namespace MFiles.VAF.Extensions.Tests.Configuration
 		[DataContract]
 		class ConfigurationWithField
 		{
+
+// Suppress warnings about default values as that's what we're actually testing.
+#pragma warning disable 0649
 			[DataMember]
 			[MFObjType(AllowEmpty = true)]
 			public MFIdentifier ObjectType;
@@ -224,6 +227,7 @@ namespace MFiles.VAF.Extensions.Tests.Configuration
 			[DataMember]
 			public ConfigurationWithField SubConfiguration;
 
+#pragma warning restore 0649
 		}
 
 		[TestMethod]

--- a/MFiles.VAF.Extensions/Dashboards/Commands/DownloadSelectedLogsDashboardCommand.cs
+++ b/MFiles.VAF.Extensions/Dashboards/Commands/DownloadSelectedLogsDashboardCommand.cs
@@ -69,6 +69,7 @@ namespace MFiles.VAF.Extensions.Dashboards.Commands
 			var fileSizes = new List<string>();
 			long totalSize = 0;
 			long archiveSize = 0;
+			int inaccessibleFileCount = 0;
 			using (var memStream = new MemoryStream())
 			{
 				// Build the archive.
@@ -77,31 +78,49 @@ namespace MFiles.VAF.Extensions.Dashboards.Commands
 					// Add each log file to the archive.
 					foreach (string relPath in files)
 					{
-						// Sanity and safety check.
-						// All paths must be inside the log folder.
-						var fullPath = Path.GetFullPath(Path.Combine(rootPath, relPath));
-						if (!fullPath.StartsWith(rootPath) ||
-							Path.GetExtension(fullPath).ToLower() != ".log" ||
-							!File.Exists(fullPath))
-							throw new FileNotFoundException();
-
-						// Add the file to the archive.
-						// NOTE:
-						//   We can't use archive.CreateEntryFromFile, because the log file may be
-						//   open by the logger, and the method doesn't have options for how we open
-						//   the file. To avoid issues, we must open the file with FileShare.ReadWrite.
-						var fileEntry = archive.CreateEntry(relPath, CompressionLevel.Optimal);
-						using (FileStream fileStream = File.Open(
-								fullPath, FileMode.Open, FileAccess.Read, FileShare.ReadWrite))
-						using (Stream entryStream = fileEntry.Open())
+						ZipArchiveEntry fileEntry = null;
+						string fullPath = null;
+						try
 						{
-							// Copy the file to the archive.
-							fileStream.CopyTo(entryStream);
+							// Sanity and safety check.
+							// All paths must be inside the log folder.
+							fullPath = Path.GetFullPath(Path.Combine(rootPath, relPath));
+							if (!fullPath.StartsWith(rootPath) ||
+								Path.GetExtension(fullPath).ToLower() != ".log" ||
+								!File.Exists(fullPath))
+								throw new FileNotFoundException();
 
-							// Bookkeeping.
-							var fileSize = fileStream.Length;
-							fileSizes.Add($"{relPath}: {fileSize} bytes");
-							totalSize += fileSize;
+							// Add the file to the archive.
+							// NOTE:
+							//   We can't use archive.CreateEntryFromFile, because the log file may be
+							//   open by the logger, and the method doesn't have options for how we open
+							//   the file. To avoid issues, we must open the file with FileShare.ReadWrite.
+							using (FileStream fileStream = File.Open(
+									fullPath, FileMode.Open, FileAccess.Read, FileShare.ReadWrite))
+							{
+								fileEntry = archive.CreateEntry(relPath, CompressionLevel.Optimal);
+								using (Stream entryStream = fileEntry.Open())
+								{
+									// Copy the file to the archive.
+									fileStream.CopyTo(entryStream);
+
+									// Bookkeeping.
+									var fileSize = fileStream.Length;
+									fileSizes.Add($"{relPath}: {fileSize} bytes");
+									totalSize += fileSize;
+								}
+							}
+						}
+						catch (Exception e)
+						{
+							// The file was likely inaccessible.  This can happen in some situations
+							// where the container is recycled and the file is locked.
+							inaccessibleFileCount++;
+
+							this.Logger.Error(e, $"Cannot add {relPath} to the log download.");
+
+							// Ensure we don't have a value in the zip for this file.
+							try { fileEntry?.Delete(); } catch { }
 						}
 					}
 				}
@@ -119,6 +138,15 @@ namespace MFiles.VAF.Extensions.Dashboards.Commands
 					$"Files:\n" +
 					String.Join( "\n - ", fileSizes ) );
 			*/
+
+			// If some files weren't accessible then inform the user.
+			if(inaccessibleFileCount > 0)
+			{
+				clientOps.ShowMessage
+				(
+					string.Format(Resources.Exceptions.Dashboard.LogFileDownloadIncomplete, inaccessibleFileCount)
+				);
+			}
 
 			// Prompt the user to download the archive.
 			clientOps.Directives.Add(new PromptDownloadFile

--- a/MFiles.VAF.Extensions/Dashboards/Commands/DownloadSelectedLogsDashboardCommand.cs
+++ b/MFiles.VAF.Extensions/Dashboards/Commands/DownloadSelectedLogsDashboardCommand.cs
@@ -117,7 +117,7 @@ namespace MFiles.VAF.Extensions.Dashboards.Commands
 							// where the container is recycled and the file is locked.
 							inaccessibleFileCount++;
 
-							this.Logger.Error(e, $"Cannot add {relPath} to the log download.");
+							this.Logger?.Error(e, $"Cannot add {relPath} to the log download.");
 
 							// Ensure we don't have a value in the zip for this file.
 							try { fileEntry?.Delete(); } catch { }

--- a/MFiles.VAF.Extensions/Dashboards/Commands/DownloadSelectedLogsDashboardCommand.cs
+++ b/MFiles.VAF.Extensions/Dashboards/Commands/DownloadSelectedLogsDashboardCommand.cs
@@ -117,7 +117,7 @@ namespace MFiles.VAF.Extensions.Dashboards.Commands
 							// where the container is recycled and the file is locked.
 							inaccessibleFileCount++;
 
-							this.Logger?.Error(e, $"Cannot add {relPath} to the log download.");
+							this.Logger?.Warn(e, $"Cannot add {relPath} to the log download.");
 
 							// Ensure we don't have a value in the zip for this file.
 							try { fileEntry?.Delete(); } catch { }
@@ -142,6 +142,7 @@ namespace MFiles.VAF.Extensions.Dashboards.Commands
 			// If some files weren't accessible then inform the user.
 			if(inaccessibleFileCount > 0)
 			{
+				this.Logger?.Error($"There were {inaccessibleFileCount} files that could not be added to the log download.");
 				clientOps.ShowMessage
 				(
 					string.Format(Resources.Exceptions.Dashboard.LogFileDownloadIncomplete, inaccessibleFileCount)

--- a/MFiles.VAF.Extensions/Resources/Exceptions/Dashboard.Designer.cs
+++ b/MFiles.VAF.Extensions/Resources/Exceptions/Dashboard.Designer.cs
@@ -61,6 +61,15 @@ namespace MFiles.VAF.Extensions.Resources.Exceptions {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to {0} file(s) could not be added to the log download.  This can happen when files are inaccessible due to container recycle or similar.  The log data may be incomplete..
+        /// </summary>
+        internal static string LogFileDownloadIncomplete {
+            get {
+                return ResourceManager.GetString("LogFileDownloadIncomplete", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to XML fragment for {0} was null so cannot be rendered..
         /// </summary>
         internal static string XmlFragmentNull {

--- a/MFiles.VAF.Extensions/Resources/Exceptions/Dashboard.resx
+++ b/MFiles.VAF.Extensions/Resources/Exceptions/Dashboard.resx
@@ -117,6 +117,10 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
+  <data name="LogFileDownloadIncomplete" xml:space="preserve">
+    <value>{0} file(s) could not be added to the log download.  This can happen when files are inaccessible due to container recycle or similar.  The log data may be incomplete.</value>
+    <comment>{0} is replaced with the number of files affected.</comment>
+  </data>
   <data name="XmlFragmentNull" xml:space="preserve">
     <value>XML fragment for {0} was null so cannot be rendered.</value>
     <comment>Thrown if a dashboard component returns a null XML (XHTML) fragment. {0} will be replaced with the name of the component.</comment>


### PR DESCRIPTION
Fix for #134 (if a log file is unavailable, exception is shown to the user and log cannot be downloaded).

Situation:
In some cases the log file may be on disk but inaccessible (e.g. it is locked by another process).  In these cases the log cannot be downloaded.

Improvement:
Inaccessible logs will be skipped but a user will be shown a message to show that the download may be missing some files.