### PR TITLE
Fix for #136

### DIFF
--- a/MFiles.VAF.Extensions/Dashboards/Commands/CustomDomainCommandResolution/AsynchronousOperationCustomDomainCommandResolver.cs
+++ b/MFiles.VAF.Extensions/Dashboards/Commands/CustomDomainCommandResolution/AsynchronousOperationCustomDomainCommandResolver.cs
@@ -53,7 +53,7 @@ namespace MFiles.VAF.Extensions.Dashboards.Commands.CustomDomainCommandResolutio
 			// Get the background operations that have a run command.
 			// Note: this should be all of them.
 			foreach (var c in
-				GetType()
+				VaultApplication.GetType()
 				.GetPropertiesAndFieldsOfType<TaskQueueBackgroundOperationManager<TSecureConfiguration>>(VaultApplication)
 				.SelectMany(tqbom => tqbom.BackgroundOperations)
 				.AsEnumerable()


### PR DESCRIPTION
The type data passed to retrieve the background-operation-manager-registered command was incorrect, so commands were not returned correctly.  As the commands were not returned correctly, clicking the button on the dashboard didn't wire up the click event for the command.

Resolved issue and added unit test to ensure that these sorts of commands are returned.