### PR TITLE
Potential fix for #141

### DIFF
--- a/MFiles.VAF.Extensions.Tests/Configuration/ScheduledExecution/DailyTriggerTests.cs
+++ b/MFiles.VAF.Extensions.Tests/Configuration/ScheduledExecution/DailyTriggerTests.cs
@@ -30,6 +30,19 @@ namespace MFiles.VAF.Extensions.Tests.ScheduledExecution
 			}.GetNextExecution(after, timezoneInfo);
 			Assert.AreEqual(expected?.ToUniversalTime(), execution?.ToUniversalTime());
 		}
+		[TestMethod]
+		public void NullAfterDoesNotThrow
+		(
+		)
+		{
+			var execution = new DailyTrigger()
+			{
+				TriggerTimes = new List<TimeSpan>
+				{
+					new TimeSpan(10, 0, 0)
+				}
+			}.GetNextExecution(null);
+		}
 
 		public static IEnumerable<object[]> GetNextExecutionData()
 		{

--- a/MFiles.VAF.Extensions/Configuration/ScheduledExecution/DailyTrigger.cs
+++ b/MFiles.VAF.Extensions/Configuration/ScheduledExecution/DailyTrigger.cs
@@ -59,8 +59,8 @@ namespace MFiles.VAF.Extensions.ScheduledExecution
 			timeZoneInfo = timeZoneInfo ?? TimeZoneInfo.Local;
 
 			// When should we start looking?
-			var before = after.Value;
-			after = (after ?? DateTime.UtcNow).ToUniversalTime();
+			var before = (after ?? DateTime.UtcNow);
+			after = before.ToUniversalTime();
 
 			// Convert the time into the timezone we're after.
 			after = TimeZoneInfo.ConvertTime(after.Value, timeZoneInfo);

--- a/MFiles.VAF.Extensions/Configuration/ScheduledExecution/Schedule.cs
+++ b/MFiles.VAF.Extensions/Configuration/ScheduledExecution/Schedule.cs
@@ -108,7 +108,8 @@ namespace MFiles.VAF.Extensions.ScheduledExecution
 			// Get the next execution date from the triggers.
 			var next = this.Triggers?
 				.Select(t => t.GetNextExecution(after, timeZoneInfo))
-				.Where(d => d.HasValue && d.Value.DateTime != DateTime.MinValue)
+				.Where(d => d.HasValue)
+				.Where(d => d.Value.DateTime != DateTime.MinValue)
 				.OrderBy(d => d);
 			return next.Any() ? next.First() : null;
 		}


### PR DESCRIPTION
I had a similar exception when testing the changes in the release that seems to be causing the issue.  At that time a LINQ "where" clause both checked that the datetimeoffset had a value, and checked that the value was not a minimum datetime.  Splitting that check into two (one where for the value, one for the value check) resolved the issue at the time.

This branch applies the same logic to the top-level Schedule call.

As I cannot yet reproduce the issue this is a stab in the dark.