### PR TITLE
Issue 145 - Add Variable Day of Month Option for DayOfMonthTrigger

### DIFF
--- a/MFiles.VAF.Extensions.Tests/Configuration/ScheduledExecution/DayOfMonthTriggerTests.cs
+++ b/MFiles.VAF.Extensions.Tests/Configuration/ScheduledExecution/DayOfMonthTriggerTests.cs
@@ -270,15 +270,394 @@ namespace MFiles.VAF.Extensions.Tests.ScheduledExecution
 				UnrepresentableDateHandling.LastDayOfMonth,
 				new DateTimeOffset?[] { new DateTimeOffset(2024, 02, 29, 0, 0, 0, 0, TimeSpan.Zero) }
 			};
-			// Variable Day: -1st Saturday of March -> Invalid
-			//yield return new object[]
-			//{
-			//	new DateTimeOffset(2025, )
-			//}
+
+			/*
+			 Three Main Cases (not including Invalids): 
+				A: Cur Date < This Month Run Date - Get This Month's run (or skip/EoM if scheduled date DNE)
+				B: Cur Date > This Month Run Date - Only return next month's run.  
+				C: Cur Date = This Month Run Date - This Month's run (Either b/c of normal sched or because of EoM) & Next Month's Run.
+			 
+			 */
+			// INVALID: -1st Sat of Month -> null
+			yield return new object[]
+			{
+				new DateTimeOffset(2025, 2, 5, 0, 0, 0, TimeSpan.Zero),
+				-1,
+				UnrepresentableDateHandling.Skip,
+				new DateTimeOffset?[0],
+				DayOfMonthTriggerType.VariableDate,
+				-1,
+				DayOfWeek.Saturday
+			};
+			// INVALID: 6th Sat of Month -> null
+			yield return new object[]
+			{
+				new DateTimeOffset(2025, 2, 5, 0, 0, 0, TimeSpan.Zero),
+				-1,
+				UnrepresentableDateHandling.Skip,
+				new DateTimeOffset?[0],
+				DayOfMonthTriggerType.VariableDate,
+				6,
+				DayOfWeek.Saturday
+			};
+			// Case A - Normal - 1st Sun 
+			yield return new object[]
+			{
+				new DateTimeOffset(2025, 2, 1, 0, 0, 0, TimeSpan.Zero),
+				-1,
+				UnrepresentableDateHandling.Skip,
+				new DateTimeOffset?[]{ new DateTimeOffset(2025, 2,2,0,0,0,TimeSpan.Zero)},
+				DayOfMonthTriggerType.VariableDate,
+				1,
+				DayOfWeek.Sunday
+			};
+			// Case A - Normal - 2nd Tuesday
+			yield return new object[]
+			{
+				new DateTimeOffset(2025, 2, 2, 0, 0, 0, TimeSpan.Zero),
+				-1,
+				UnrepresentableDateHandling.Skip,
+				new DateTimeOffset?[]{ new DateTimeOffset(2025, 2,11,0,0,0,TimeSpan.Zero)},
+				DayOfMonthTriggerType.VariableDate,
+				2,
+				DayOfWeek.Tuesday
+			};
+			// Case A - Normal - 4th Friday (last day)
+			yield return new object[]
+			{
+				new DateTimeOffset(2025, 2, 3, 0, 0, 0, TimeSpan.Zero),
+				-1,
+				UnrepresentableDateHandling.Skip,
+				new DateTimeOffset?[]{ new DateTimeOffset(2025, 2,28,0,0,0,TimeSpan.Zero)},
+				DayOfMonthTriggerType.VariableDate,
+				4,
+				DayOfWeek.Friday
+			};
+			// Case A - DNE - EoM - 5th Saturday
+			yield return new object[]
+			{
+				new DateTimeOffset(2025, 2, 4, 0, 0, 0, TimeSpan.Zero),
+				-1,
+				UnrepresentableDateHandling.LastDayOfMonth,
+				new DateTimeOffset?[]{ new DateTimeOffset(2025, 2,28,0,0,0,TimeSpan.Zero)},
+				DayOfMonthTriggerType.VariableDate,
+				5,
+				DayOfWeek.Saturday
+			};
+			// Case A - DNE - EoM - 5th Friday
+			yield return new object[]
+			{
+				new DateTimeOffset(2025, 2, 4, 0, 0, 0, TimeSpan.Zero),
+				-1,
+				UnrepresentableDateHandling.LastDayOfMonth,
+				new DateTimeOffset?[]{ new DateTimeOffset(2025, 2,28,0,0,0,TimeSpan.Zero)},
+				DayOfMonthTriggerType.VariableDate,
+				5,
+				DayOfWeek.Friday
+			};
+			// A - DNE - SKIP - 5th Saturday - Skip 1 Month
+			yield return new object[]
+			{
+				new DateTimeOffset(2025, 2, 4,0, 0, 0, TimeSpan.Zero),
+				-1,
+				UnrepresentableDateHandling.Skip,
+				new DateTimeOffset?[]{ new DateTimeOffset(2025, 3,29,0,0,0,TimeSpan.Zero)},
+				DayOfMonthTriggerType.VariableDate,
+				5,
+				DayOfWeek.Saturday
+			};
+			// A - DNE - SKIP - 5th Tuesday- Skip 2 Months
+			yield return new object[]
+			{
+				new DateTimeOffset(2025, 2, 4, 0, 0, 0, TimeSpan.Zero),
+				-1,
+				UnrepresentableDateHandling.Skip,
+				new DateTimeOffset?[]{ new DateTimeOffset(2025, 4,29,0,0,0,TimeSpan.Zero)},
+				DayOfMonthTriggerType.VariableDate,
+				5,
+				DayOfWeek.Tuesday
+			};
+			// A- EoY - DNE - EoM - 5th Friday
+			yield return new object[]
+			{
+				new DateTimeOffset(2025, 12, 4, 0, 0, 0, TimeSpan.Zero),
+				-1,
+				UnrepresentableDateHandling.LastDayOfMonth,
+				new DateTimeOffset?[]{ new DateTimeOffset(2025, 12,31,0,0,0,TimeSpan.Zero)},
+				DayOfMonthTriggerType.VariableDate,
+				5,
+				DayOfWeek.Friday
+			};
+			// A - EoY - DNE - SKIP - 5th Friday
+			yield return new object[]
+			{
+				new DateTimeOffset(2025, 12, 4, 0, 0, 0, TimeSpan.Zero),
+				-1,
+				UnrepresentableDateHandling.Skip,
+				new DateTimeOffset?[]{ new DateTimeOffset(2026, 1,30,0,0,0,TimeSpan.Zero)},
+				DayOfMonthTriggerType.VariableDate,
+				5,
+				DayOfWeek.Friday
+			};
+			// A- EoY - DNE - SKIP - 5th Sunday - skip 3 months
+			yield return new object[]
+			{
+				new DateTimeOffset(2025, 12, 4, 0, 0, 0, TimeSpan.Zero),
+				-1,
+				UnrepresentableDateHandling.Skip,
+				new DateTimeOffset?[]{ new DateTimeOffset(2026, 3,29,0,0,0,TimeSpan.Zero)},
+				DayOfMonthTriggerType.VariableDate,
+				5,
+				DayOfWeek.Sunday
+			};
+			// B - Normal - 1st Sun
+			yield return new object[]
+			{
+				new DateTimeOffset(2025, 1, 20, 0, 0, 0, TimeSpan.Zero),
+				-1,
+				UnrepresentableDateHandling.Skip,
+				new DateTimeOffset?[]{ new DateTimeOffset(2025, 2,2,0,0,0,TimeSpan.Zero)},
+				DayOfMonthTriggerType.VariableDate,
+				1,
+				DayOfWeek.Sunday
+			};
+			// B - Normal - 2nd Tuesday
+			yield return new object[]
+			{
+				new DateTimeOffset(2025, 1, 20, 0, 0, 0, TimeSpan.Zero),
+				-1,
+				UnrepresentableDateHandling.Skip,
+				new DateTimeOffset?[]{ new DateTimeOffset(2025, 2,11,0,0,0,TimeSpan.Zero)},
+				DayOfMonthTriggerType.VariableDate,
+				2,
+				DayOfWeek.Tuesday
+			};
+			// B-Normal - 4th Friday (last day)
+			yield return new object[]
+			{
+				new DateTimeOffset(2025, 1, 25, 0, 0, 0, TimeSpan.Zero),
+				-1,
+				UnrepresentableDateHandling.Skip,
+				new DateTimeOffset?[]{ new DateTimeOffset(2025, 2,28,0,0,0,TimeSpan.Zero)},
+				DayOfMonthTriggerType.VariableDate,
+				4,
+				DayOfWeek.Friday
+			};
+			// B - DNE - EoM - 5th Thursday
+			yield return new object[]
+			{
+				new DateTimeOffset(2025, 1, 31, 0, 0, 0, TimeSpan.Zero),
+				-1,
+				UnrepresentableDateHandling.LastDayOfMonth,
+				new DateTimeOffset?[]{ new DateTimeOffset(2025, 2,28,0,0,0,TimeSpan.Zero)},
+				DayOfMonthTriggerType.VariableDate,
+				5,
+				DayOfWeek.Thursday
+			};
+			// B - DNE - SKIP - 5th Wednesday - Skip 2 Months
+			yield return new object[]
+			{
+				new DateTimeOffset(2025, 1, 30, 0, 0, 0, TimeSpan.Zero),
+				-1,
+				UnrepresentableDateHandling.Skip,
+				new DateTimeOffset?[]{ new DateTimeOffset(2025, 4,30,0,0,0,TimeSpan.Zero)},
+				DayOfMonthTriggerType.VariableDate,
+				5,
+				DayOfWeek.Wednesday
+			};
+			// B - EoY - Normal - 4th Thursday 
+			yield return new object[]
+			{
+				new DateTimeOffset(2025, 12, 28, 0, 0, 0, TimeSpan.Zero),
+				-1,
+				UnrepresentableDateHandling.Skip,
+				new DateTimeOffset?[]{ new DateTimeOffset(2026, 1,22,0,0,0,TimeSpan.Zero)},
+				DayOfMonthTriggerType.VariableDate,
+				4,
+				DayOfWeek.Thursday
+			};
+			// B - EoY -DNE - SKIP - 5th Saturday Skip 2 Months from Nov
+			yield return new object[]
+			{
+				new DateTimeOffset(2025, 11, 30, 0, 0, 0, TimeSpan.Zero),
+				-1,
+				UnrepresentableDateHandling.Skip,
+				new DateTimeOffset?[]{ new DateTimeOffset(2026, 1, 31,0,0,0,TimeSpan.Zero)},
+				DayOfMonthTriggerType.VariableDate,
+				5,
+				DayOfWeek.Saturday
+			};
+			// B - EoY DNE - EoM - 5th Monday
+			yield return new object[]
+			{
+				new DateTimeOffset(2025, 12, 30, 0, 0, 0, TimeSpan.Zero),
+				-1,
+				UnrepresentableDateHandling.LastDayOfMonth,
+				new DateTimeOffset?[]{ new DateTimeOffset(2026, 1, 31,0,0,0,TimeSpan.Zero)},
+				DayOfMonthTriggerType.VariableDate,
+				5,
+				DayOfWeek.Monday
+			};
+			// B - EoY DNE -SKIP - 5th Monday
+			yield return new object[]
+			{
+				new DateTimeOffset(2025, 12, 30, 0, 0, 0, TimeSpan.Zero),
+				-1,
+				UnrepresentableDateHandling.Skip,
+				new DateTimeOffset?[]{ new DateTimeOffset(2026, 3, 30,0,0,0,TimeSpan.Zero)},
+				DayOfMonthTriggerType.VariableDate,
+				5,
+				DayOfWeek.Monday
+			};
+			// C - Normal - 1st Wednesday
+			yield return new object[]
+			{
+				new DateTimeOffset(2025, 2, 5, 0, 0, 0, TimeSpan.Zero),
+				-1,
+				UnrepresentableDateHandling.Skip,
+				new DateTimeOffset?[]{ new DateTimeOffset(2025, 2, 5,0,0,0,TimeSpan.Zero),
+									   new DateTimeOffset(2025, 3, 5,0,0,0,TimeSpan.Zero)},
+				DayOfMonthTriggerType.VariableDate,
+				1,
+				DayOfWeek.Wednesday
+			};
+			// C - Normal - 3rd Sunday
+			yield return new object[]
+			{
+				new DateTimeOffset(2025, 3, 16, 0, 0, 0, TimeSpan.Zero),
+				-1,
+				UnrepresentableDateHandling.Skip,
+				new DateTimeOffset?[]{ new DateTimeOffset(2025, 3, 16,0,0,0,TimeSpan.Zero),
+									   new DateTimeOffset(2025, 4, 20,0,0,0,TimeSpan.Zero)},
+				DayOfMonthTriggerType.VariableDate,
+				3,
+				DayOfWeek.Sunday
+			};
+			// C - Next Month DNE - SKIP- 5th Thursday
+			yield return new object[]
+			{
+				new DateTimeOffset(2025, 5, 29, 0, 0, 0, TimeSpan.Zero),
+				-1,
+				UnrepresentableDateHandling.Skip,
+				new DateTimeOffset?[]{ new DateTimeOffset(2025, 5, 29,0,0,0,TimeSpan.Zero),
+									   new DateTimeOffset(2025, 7, 31,0,0,0,TimeSpan.Zero)},
+				DayOfMonthTriggerType.VariableDate,
+				5,
+				DayOfWeek.Thursday
+			};
+			// C - 2 Months DNE - SKIP - 5th Friday
+			yield return new object[]
+			{
+				new DateTimeOffset(2025, 5, 30, 0, 0, 0, TimeSpan.Zero),
+				-1,
+				UnrepresentableDateHandling.Skip,
+				new DateTimeOffset?[]{ new DateTimeOffset(2025, 5, 30,0,0,0,TimeSpan.Zero),
+									   new DateTimeOffset(2025, 8, 29,0,0,0,TimeSpan.Zero)},
+				DayOfMonthTriggerType.VariableDate,
+				5,
+				DayOfWeek.Friday
+			};
+			// C - Next Month DNE - EoM - 5th Thurs
+			yield return new object[]
+			{
+				new DateTimeOffset(2025, 5,29, 0, 0, 0, TimeSpan.Zero),
+				-1,
+				UnrepresentableDateHandling.LastDayOfMonth,
+				new DateTimeOffset?[]{ new DateTimeOffset(2025, 5, 29,0,0,0,TimeSpan.Zero),
+									   new DateTimeOffset(2025, 6, 30,0,0,0,TimeSpan.Zero)},
+				DayOfMonthTriggerType.VariableDate,
+				5,
+				DayOfWeek.Thursday
+			};
+			// C - This  Month DNE - EoM - 5th Monday
+			yield return new object[]
+			{
+				new DateTimeOffset(2025, 5,31, 0, 0, 0, TimeSpan.Zero),
+				-1,
+				UnrepresentableDateHandling.LastDayOfMonth,
+				new DateTimeOffset?[]{ new DateTimeOffset(2025, 5, 31,0,0,0,TimeSpan.Zero),
+									   new DateTimeOffset(2025, 6, 30,0,0,0,TimeSpan.Zero)},
+				DayOfMonthTriggerType.VariableDate,
+				5,
+				DayOfWeek.Monday
+			};
+			// C - EoY - Normal - 3rd Saturday
+			yield return new object[]
+			{
+				new DateTimeOffset(2025, 12,20, 0, 0, 0, TimeSpan.Zero),
+				-1,
+				UnrepresentableDateHandling.Skip,
+				new DateTimeOffset?[]{ new DateTimeOffset(2025, 12, 20,0,0,0,TimeSpan.Zero),
+									   new DateTimeOffset(2026, 1, 17,0,0,0,TimeSpan.Zero)},
+				DayOfMonthTriggerType.VariableDate,
+				3,
+				DayOfWeek.Saturday
+			};
+			// C - EoY - Next Month DNE - 5th Monday
+			yield return new object[]
+			{
+				new DateTimeOffset(2025, 12,29, 0, 0, 0, TimeSpan.Zero),
+				-1,
+				UnrepresentableDateHandling.Skip,
+				new DateTimeOffset?[]{ new DateTimeOffset(2025, 12, 29,0,0,0,TimeSpan.Zero),
+									   new DateTimeOffset(2026, 3, 30,0,0,0,TimeSpan.Zero)},
+				DayOfMonthTriggerType.VariableDate,
+				5,
+				DayOfWeek.Monday
+			};
+			// C - EoY - Next Month DNE - EoM - 5th Monday
+			yield return new object[]
+			{
+				new DateTimeOffset(2025, 12,29, 0, 0, 0, TimeSpan.Zero),
+				-1,
+				UnrepresentableDateHandling.LastDayOfMonth,
+				new DateTimeOffset?[]{ new DateTimeOffset(2025, 12, 29,0,0,0,TimeSpan.Zero),
+									   new DateTimeOffset(2026, 1, 31,0,0,0,TimeSpan.Zero)},
+				DayOfMonthTriggerType.VariableDate,
+				5,
+				DayOfWeek.Monday
+			};
+			// C - EoY  -This Month DNE -   EoM - 5th Thurday
+			yield return new object[]
+			{
+				new DateTimeOffset(2025, 12,31, 0, 0, 0, TimeSpan.Zero),
+				-1,
+				UnrepresentableDateHandling.LastDayOfMonth,
+				new DateTimeOffset?[]{ new DateTimeOffset(2025, 12, 31,0,0,0,TimeSpan.Zero),
+									   new DateTimeOffset(2026, 1, 29,0,0,0,TimeSpan.Zero)},
+				DayOfMonthTriggerType.VariableDate,
+				5,
+				DayOfWeek.Thursday
+			};
+			// C - EoY - This AND Next Month DNE - EoM - 5th Sunday
+			yield return new object[]
+			{
+				new DateTimeOffset(2025, 12,31, 0, 0, 0, TimeSpan.Zero),
+				-1,
+				UnrepresentableDateHandling.LastDayOfMonth,
+				new DateTimeOffset?[]{ new DateTimeOffset(2025, 12, 31,0,0,0,TimeSpan.Zero),
+									   new DateTimeOffset(2026, 1, 31,0,0,0,TimeSpan.Zero)},
+				DayOfMonthTriggerType.VariableDate,
+				5,
+				DayOfWeek.Sunday
+			};
+			// C - EoY(Nov) - Next Month DNE - SKIP
+			yield return new object[]
+			{
+				new DateTimeOffset(2025, 11,29, 0, 0, 0, TimeSpan.Zero),
+				-1,
+				UnrepresentableDateHandling.Skip,
+				new DateTimeOffset?[]{ new DateTimeOffset(2025, 11, 29,0,0,0,TimeSpan.Zero),
+									   new DateTimeOffset(2026, 1, 31,0,0,0,TimeSpan.Zero)},
+				DayOfMonthTriggerType.VariableDate,
+				5,
+				DayOfWeek.Saturday
+			};
+			
 		}
 		public static IEnumerable<object[]> GetVariableDateOfMonthData()
 		{
-			// -1st Wednesday (Invalid) -> -1
+			//Test Case #1: -1st Wednesday (Invalid) -> -1
 			yield return new object[]
 			{
 				new DateTimeOffset(2025, 2, 23, 1, 2, 3, TimeSpan.Zero),
@@ -286,7 +665,7 @@ namespace MFiles.VAF.Extensions.Tests.ScheduledExecution
 				DayOfWeek.Wednesday,
 				-1
 			};
-			// 6th Thursday (Invalid) -> -1
+			//Test Case #2: 6th Thursday (Invalid) -> -1
 			yield return new object[]
 			{
 				new DateTimeOffset(2025, 2, 23, 1, 2, 3, TimeSpan.Zero),
@@ -294,7 +673,7 @@ namespace MFiles.VAF.Extensions.Tests.ScheduledExecution
 				DayOfWeek.Thursday,
 				-1
 			};
-			// 1st Friday of Jan 2025 -> 3
+			//Test Case #3: 1st Friday of Jan 2025 -> 3
 			yield return new object[]
 			{
 				new DateTimeOffset(2025, 1, 23, 1, 2, 3, TimeSpan.Zero),
@@ -302,7 +681,7 @@ namespace MFiles.VAF.Extensions.Tests.ScheduledExecution
 				DayOfWeek.Friday,
 				3
 			};
-			// 1st Wednesday of Jan 2025 (1st of the month) -> 1
+			//Test Case #4 1st Wednesday of Jan 2025 (1st of the month) -> 1
 			yield return new object[]
 			{
 				new DateTimeOffset(2025, 1, 23, 1, 2, 3, TimeSpan.Zero),
@@ -310,7 +689,7 @@ namespace MFiles.VAF.Extensions.Tests.ScheduledExecution
 				DayOfWeek.Wednesday,
 				1
 			};
-			// 2nd Thursday of Jan 2025 -> 9
+			//Test Case #5: 2nd Thursday of Jan 2025 -> 9
 			yield return new object[]
 			{
 				new DateTimeOffset(2025, 1, 3, 1, 2, 3, TimeSpan.Zero),
@@ -318,7 +697,7 @@ namespace MFiles.VAF.Extensions.Tests.ScheduledExecution
 				DayOfWeek.Thursday,
 				9
 			};
-			// 2nd Wednesday of Jan 2025 -> 8
+			//Test Case: #6 2nd Wednesday of Jan 2025 -> 8
 			yield return new object[]
 			{
 				new DateTimeOffset(2025, 1, 13, 1, 2, 3, TimeSpan.Zero),
@@ -326,7 +705,7 @@ namespace MFiles.VAF.Extensions.Tests.ScheduledExecution
 				DayOfWeek.Wednesday,
 				8
 			};
-			// 1st Tuesday of Jan 2025 -> 7
+			//Test Case #7: 1st Tuesday of Jan 2025 -> 7
 			yield return new object[]
 			{
 				new DateTimeOffset(2025, 1, 13, 1, 2, 3, TimeSpan.Zero),
@@ -334,7 +713,7 @@ namespace MFiles.VAF.Extensions.Tests.ScheduledExecution
 				DayOfWeek.Tuesday,
 				7
 			};
-			// 4th Monday of Jan 2025 -> 27
+			//Test Case #8: 4th Monday of Jan 2025 -> 27
 			yield return new object[]
 			{
 				new DateTimeOffset(2025, 1, 13, 1, 2, 3, TimeSpan.Zero),
@@ -342,7 +721,7 @@ namespace MFiles.VAF.Extensions.Tests.ScheduledExecution
 				DayOfWeek.Monday,
 				27
 			};
-			// 5th Wednesday of Jan 2025 -> 27
+			//Test Case #9: 5th Wednesday of Jan 2025 -> 27
 			yield return new object[]
 			{
 				new DateTimeOffset(2025, 1, 13, 1, 2, 3, TimeSpan.Zero),
@@ -350,7 +729,7 @@ namespace MFiles.VAF.Extensions.Tests.ScheduledExecution
 				DayOfWeek.Wednesday,
 				29
 			};
-			// 5th Friday of Jan 2025 (Last day of month) -> 31
+			//Test Case #10: 5th Friday of Jan 2025 (Last day of month) -> 31
 			yield return new object[]
 			{
 				new DateTimeOffset(2025, 1, 13, 1, 2, 3, TimeSpan.Zero),
@@ -358,7 +737,7 @@ namespace MFiles.VAF.Extensions.Tests.ScheduledExecution
 				DayOfWeek.Friday,
 				31
 			};
-			// 5th Saturday of Jan 2025 (Does not exist) -> -1
+			//Test Case #11: 5th Saturday of Jan 2025 (Does not exist) -> -1
 			yield return new object[]
 			{
 				new DateTimeOffset(2025, 1, 13, 1, 2, 3, TimeSpan.Zero),
@@ -366,7 +745,7 @@ namespace MFiles.VAF.Extensions.Tests.ScheduledExecution
 				DayOfWeek.Saturday, 
 				-1
 			};
-			// 5th Monday of Jan 2025 (Does not exist) -> -1
+			//Test Case #12: 5th Monday of Jan 2025 (Does not exist) -> -1
 			yield return new object[]
 			{
 				new DateTimeOffset(2025, 1, 13, 1, 2, 3, TimeSpan.Zero),
@@ -374,7 +753,7 @@ namespace MFiles.VAF.Extensions.Tests.ScheduledExecution
 				DayOfWeek.Monday, 
 				-1
 			};
-			// Feb Testing: 4th Friday of Feb 2025 -> 28
+			//Test Case #13: Feb Testing: 4th Friday of Feb 2025 -> 28
 			yield return new object[]
 			{
 				new DateTimeOffset(2025, 2, 13, 1, 2, 3, TimeSpan.Zero),
@@ -382,7 +761,7 @@ namespace MFiles.VAF.Extensions.Tests.ScheduledExecution
 				DayOfWeek.Friday, 
 				28
 			};
-			// Feb Testing: 4th Saturday of Feb 2025 -> 22
+			//Test Case #14: Feb Testing: 4th Saturday of Feb 2025 -> 22
 			yield return new object[]
 			{
 				new DateTimeOffset(2025, 2, 13, 1, 2, 3, TimeSpan.Zero),
@@ -390,7 +769,7 @@ namespace MFiles.VAF.Extensions.Tests.ScheduledExecution
 				DayOfWeek.Saturday,
 				22
 			};
-			// Feb Testing: 5th Saturday of Feb 2025 (Does not exist) -> -1 
+			//Test Case #15: Feb Testing: 5th Saturday of Feb 2025 (Does not exist) -> -1 
 			yield return new object[]
 			{
 				new DateTimeOffset(2025, 2, 13, 1, 2, 3, TimeSpan.Zero),
@@ -398,7 +777,7 @@ namespace MFiles.VAF.Extensions.Tests.ScheduledExecution
 				DayOfWeek.Saturday,
 				-1
 			};
-			// Feb Testing LEAP YEAR: 4th Monday of Feb 2028-> 28
+			//Test Case #16: Feb Testing LEAP YEAR: 4th Monday of Feb 2028-> 28
 			yield return new object[]
 			{
 				new DateTimeOffset(2028, 2, 13, 1, 2, 3, TimeSpan.Zero),
@@ -406,7 +785,7 @@ namespace MFiles.VAF.Extensions.Tests.ScheduledExecution
 				DayOfWeek.Monday,
 				28
 			};
-			// Feb Testing LEAP YEAR: 5th Tuesday of Feb 2028-> 29
+			//Test Case #17: Feb Testing LEAP YEAR: 5th Tuesday of Feb 2028-> 29
 			yield return new object[]
 			{
 				new DateTimeOffset(2028, 2, 13, 1, 2, 3, TimeSpan.Zero),
@@ -414,7 +793,7 @@ namespace MFiles.VAF.Extensions.Tests.ScheduledExecution
 				DayOfWeek.Tuesday,
 				29
 			};
-			// End of year: 5th Wed of Dec 2025 -> 31
+			//Test Case #18: End of year: 5th Wed of Dec 2025 -> 31
 			yield return new object[]
 			{
 				new DateTimeOffset(2025, 12, 13, 1, 2, 3, TimeSpan.Zero),
@@ -434,7 +813,7 @@ namespace MFiles.VAF.Extensions.Tests.ScheduledExecution
 		}
 		public static IEnumerable<object[]> GetNextMonthWithValidVariableDateData()
 		{
-			// Unrepresentable = SKIP - Jan 2025 - 1st Saturday -> 1 Feb 2025 
+			//Test Case #1: Unrepresentable = SKIP - Jan 2025 - 1st Saturday -> 1 Feb 2025 
 			yield return new object[]
 			{
 				new DateTimeOffset(2025, 1, 1, 1, 2, 3, TimeSpan.Zero),
@@ -443,7 +822,7 @@ namespace MFiles.VAF.Extensions.Tests.ScheduledExecution
 				DayOfWeek.Saturday,
 				new DateTimeOffset(2025, 2, 1, 0, 0, 0, TimeSpan.Zero)
 			};
-			// Unrepresentable = SKIP - Jan 2025 - 1st Sunday -> 2 Feb 2025
+			//Test Case #2: Unrepresentable = SKIP - Jan 2025 - 1st Sunday -> 2 Feb 2025
 			yield return new object[]
 			{
 				new DateTimeOffset(2025, 1, 1, 1, 2, 3, TimeSpan.Zero),
@@ -452,7 +831,7 @@ namespace MFiles.VAF.Extensions.Tests.ScheduledExecution
 				DayOfWeek.Sunday,
 				new DateTimeOffset(2025, 2, 2, 0, 0, 0, TimeSpan.Zero)
 			};
-			// Unrepresentable = SKIP - Jan 2025 - 2ND Sunday -> 9 Feb 2025
+			//Test Case #3: Unrepresentable = SKIP - Jan 2025 - 2ND Sunday -> 9 Feb 2025
 			yield return new object[]
 			{
 				new DateTimeOffset(2025, 1, 1, 1, 2, 3, TimeSpan.Zero),
@@ -461,7 +840,7 @@ namespace MFiles.VAF.Extensions.Tests.ScheduledExecution
 				DayOfWeek.Sunday,
 				new DateTimeOffset(2025, 2, 9, 0, 0, 0, TimeSpan.Zero)
 			};
-			// Unrepresentable = SKIP - Jan 2025 - 3ND Sunday -> 16 Feb 2025
+			//Test Case #4: Unrepresentable = SKIP - Jan 2025 - 3rd Sunday -> 16 Feb 2025
 			yield return new object[]
 			{
 				new DateTimeOffset(2025, 1, 1, 1, 2, 3, TimeSpan.Zero),
@@ -470,7 +849,7 @@ namespace MFiles.VAF.Extensions.Tests.ScheduledExecution
 				DayOfWeek.Sunday,
 				new DateTimeOffset(2025, 2, 16, 0, 0, 0, TimeSpan.Zero)
 			};
-			// Unrepresentable = SKIP - Jan 2025 - 4TH Sunday -> 23 Feb 2025
+			//Test Case #5: Unrepresentable = SKIP - Jan 2025 - 4TH Sunday -> 23 Feb 2025
 			yield return new object[]
 			{
 				new DateTimeOffset(2025, 1, 1, 1, 2, 3, TimeSpan.Zero),
@@ -479,7 +858,7 @@ namespace MFiles.VAF.Extensions.Tests.ScheduledExecution
 				DayOfWeek.Sunday,
 				new DateTimeOffset(2025, 2, 23, 0, 0, 0, TimeSpan.Zero)
 			};
-			// Unrepresentable = SKIP - Jan 2025 - 4TH Friday -> 28 Feb 2025
+			//Test Case #6: Unrepresentable = SKIP - Jan 2025 - 4TH Friday -> 28 Feb 2025
 			yield return new object[]
 			{
 				new DateTimeOffset(2025, 1, 1, 1, 2, 3, TimeSpan.Zero),
@@ -488,7 +867,7 @@ namespace MFiles.VAF.Extensions.Tests.ScheduledExecution
 				DayOfWeek.Friday,
 				new DateTimeOffset(2025, 2, 28, 0, 0, 0, TimeSpan.Zero)
 			};
-			// Unrepresentable = SKIP - Jan 2025 - 5TH Saturday (Invalid, Skip Feb) -> 29 March 2025
+			//Test Case 7: Unrepresentable = SKIP - Jan 2025 - 5TH Saturday (Invalid, Skip Feb) -> 29 March 2025
 			yield return new object[]
 			{
 				new DateTimeOffset(2025, 1, 1, 1, 2, 3, TimeSpan.Zero),
@@ -497,16 +876,8 @@ namespace MFiles.VAF.Extensions.Tests.ScheduledExecution
 				DayOfWeek.Saturday,
 				new DateTimeOffset(2025, 3, 29, 0, 0, 0, TimeSpan.Zero)
 			};
-			// Unrepresentable = SKIP - Jan 2025 - 5TH Wednesday (Invalid, Skip Feb AND Skip Mar) -> 30 April 2025
-			yield return new object[]
-			{
-				new DateTimeOffset(2025, 1, 1, 1, 2, 3, TimeSpan.Zero),
-				UnrepresentableDateHandling.Skip,
-				5,
-				DayOfWeek.Wednesday,
-				new DateTimeOffset(2025, 4, 30, 0, 0, 0, TimeSpan.Zero)
-			};
-			// Unrepresentable = EndOfMonth - Jan 2025 - 5TH Saturday (Invalid, use end of month) -> 28 Feb 2025
+
+			//Test Case 8: Unrepresentable = EndOfMonth - Jan 2025 - 5TH Saturday (Invalid, use end of month) -> 28 Feb 2025
 			yield return new object[]
 			{
 				new DateTimeOffset(2025, 1, 1, 1, 2, 3, TimeSpan.Zero),
@@ -515,7 +886,16 @@ namespace MFiles.VAF.Extensions.Tests.ScheduledExecution
 				DayOfWeek.Saturday,
 				new DateTimeOffset(2025, 2, 28, 0, 0, 0, TimeSpan.Zero)
 			};
-			// LEAP YEAR - Unrepresentable = SKIP - Jan 2028 - 5th Tuesday -> 29 Feb 2028
+			//Test Case 9: Unrepresentable = SKIP - Jan 2025 - 5TH Wednesday (Invalid, Skip Feb AND Skip Mar) -> 30 April 2025
+			yield return new object[]
+			{
+				new DateTimeOffset(2025, 1, 1, 1, 2, 3, TimeSpan.Zero),
+				UnrepresentableDateHandling.Skip,
+				5,
+				DayOfWeek.Wednesday,
+				new DateTimeOffset(2025, 4, 30, 0, 0, 0, TimeSpan.Zero)
+			};
+			//Test Case 10: LEAP YEAR - Unrepresentable = SKIP - Jan 2028 - 5th Tuesday -> 29 Feb 2028
 			yield return new object[]
 			{
 				new DateTimeOffset(2028, 1, 1, 1, 2, 3, TimeSpan.Zero),
@@ -524,7 +904,7 @@ namespace MFiles.VAF.Extensions.Tests.ScheduledExecution
 				DayOfWeek.Tuesday,
 				new DateTimeOffset(2028, 2, 29, 0, 0, 0, TimeSpan.Zero)
 			};
-			// LEAP YEAR - Unrepresentable = SKIP - Jan 2028 - 5th Wednesday (DNE)-> 29 Mar 2028
+			//Test Case 11: LEAP YEAR - Unrepresentable = SKIP - Jan 2028 - 5th Wednesday (DNE)-> 29 Mar 2028
 			yield return new object[]
 			{
 				new DateTimeOffset(2028, 1, 1, 1, 2, 3, TimeSpan.Zero),
@@ -533,6 +913,52 @@ namespace MFiles.VAF.Extensions.Tests.ScheduledExecution
 				DayOfWeek.Wednesday,
 				new DateTimeOffset(2028, 3, 29, 0, 0, 0, TimeSpan.Zero)
 			};
+			//Test Case 12: LEAP YEAR - Unrepresentable = EoM - Jan 2028 - 5th Wednesday (DNE)-> 29 Feb 2028
+			yield return new object[]
+			{
+				new DateTimeOffset(2028, 1, 1, 1, 2, 3, TimeSpan.Zero),
+				UnrepresentableDateHandling.LastDayOfMonth,
+				5,
+				DayOfWeek.Wednesday,
+				new DateTimeOffset(2028, 2, 29, 0, 0, 0, TimeSpan.Zero)
+			};
+			//Test Case 13: EoY - Unrepresentable = Skip - Dec 2025 - 5th Saturday (DNE)-> 31 Jan 2026
+			yield return new object[]
+			{
+				new DateTimeOffset(2025, 12, 1, 1, 2, 3, TimeSpan.Zero),
+				UnrepresentableDateHandling.Skip,
+				5,
+				DayOfWeek.Saturday,
+				new DateTimeOffset(2026, 1, 31, 0, 0, 0, TimeSpan.Zero)
+			};
+			//Test Case 14: EoY - Unrepresentable = Skip - Nov 2025 - 5th Friday (DNE)-> 30 Jan 2026
+			yield return new object[]
+			{
+				new DateTimeOffset(2025, 11, 10, 1, 2, 3, TimeSpan.Zero),
+				UnrepresentableDateHandling.Skip,
+				5,
+				DayOfWeek.Friday,
+				new DateTimeOffset(2026, 1, 30, 0, 0, 0, TimeSpan.Zero)
+			};
+			//Test Case 15: EoY - Unrepresentable = Skip - DEC 2025 - 5th Tuesday (DNE)-> 31 Mar 2026
+			yield return new object[]
+			{
+				new DateTimeOffset(2025, 12, 10, 1, 2, 3, TimeSpan.Zero),
+				UnrepresentableDateHandling.Skip,
+				5,
+				DayOfWeek.Tuesday,
+				new DateTimeOffset(2026, 3, 31, 0, 0, 0, TimeSpan.Zero)
+			};
+			//Test Case 16: EoY - Unrepresentable = EoM - DEC 2025 - 5th Tuesday (DNE)-> 31 Jan 2026
+			yield return new object[]
+			{
+				new DateTimeOffset(2025, 12, 10, 1, 2, 3, TimeSpan.Zero),
+				UnrepresentableDateHandling.LastDayOfMonth,
+				5,
+				DayOfWeek.Tuesday,
+				new DateTimeOffset(2026, 1, 31, 0, 0, 0, TimeSpan.Zero)
+			};
+
 
 
 		}

--- a/MFiles.VAF.Extensions.Tests/Configuration/ScheduledExecution/DayOfMonthTriggerTests.cs
+++ b/MFiles.VAF.Extensions.Tests/Configuration/ScheduledExecution/DayOfMonthTriggerTests.cs
@@ -83,8 +83,8 @@ namespace MFiles.VAF.Extensions.Tests.ScheduledExecution
 				{
 					TriggerTimes = triggerTimes.ToList(),
 					DayType = type, 
-					nthDay = nthWeekday,
-					weekday = dayOfWeek,
+					NthDay = nthWeekday,
+					Weekday = dayOfWeek,
 					UnrepresentableDateHandling = unrep
 				}.GetNextExecution(after, TimeZoneInfo.Utc);
 			}

--- a/MFiles.VAF.Extensions.Tests/Configuration/ScheduledExecution/DayOfMonthTriggerTests.cs
+++ b/MFiles.VAF.Extensions.Tests/Configuration/ScheduledExecution/DayOfMonthTriggerTests.cs
@@ -1,4 +1,5 @@
 ﻿using MFiles.VAF.Extensions;
+using MFiles.VAF.Extensions.Configuration.ScheduledExecution;
 using MFiles.VAF.Extensions.ScheduledExecution;
 using MFiles.VAF.Extensions.Tests.Configuration;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
@@ -23,15 +24,29 @@ namespace MFiles.VAF.Extensions.Tests.ScheduledExecution
 			DateTimeOffset after,
 			int dayOfMonth,
 			UnrepresentableDateHandling unrepresentableDateHandling,
-			DateTimeOffset?[] expected
+			DateTimeOffset?[] expected,
+			DayOfMonthTriggerType triggerType = DayOfMonthTriggerType.SpecificDate,
+			int nthWeekday = -1,
+			DayOfWeek dayOfWeek = DayOfWeek.Sunday
 		)
 		{
-			var result = DayOfMonthTrigger
+			DateTimeOffset[] result;
+			if (triggerType == DayOfMonthTriggerType.SpecificDate)
+			{
+				result = DayOfMonthTrigger
 				.GetNextDayOfMonth(after, dayOfMonth, unrepresentableDateHandling)?
 				.ToArray();
+			}
+			else
+			{
+				result = DayOfMonthTrigger
+				.GetNextDayOfMonth(after, dayOfMonth, unrepresentableDateHandling, triggerType, nthWeekday, dayOfWeek)?
+				.ToArray();
+			}
+
 			Assert.IsNotNull(result);
 			Assert.AreEqual(expected.Length, result.Length);
-			for(var i=0; i<result.Length; i++)
+			for (var i = 0; i < result.Length; i++)
 			{
 				Assert.AreEqual(expected[i], result[i]);
 			}
@@ -54,7 +69,39 @@ namespace MFiles.VAF.Extensions.Tests.ScheduledExecution
 			}.GetNextExecution(after, TimeZoneInfo.Utc);
 			Assert.AreEqual(expected?.ToUniversalTime(), execution?.ToUniversalTime());
 		}
+		[TestMethod]
+		[DynamicData(nameof(GetVariableDateOfMonthData), DynamicDataSourceType.Method)]
+		public void GetVariableDateOfMonth
+		(
+			DateTimeOffset date,
+			int nthWeekday,
+			DayOfWeek dayOfWeek,
+			int expected
+		)
+		{
+			var result = DayOfMonthTrigger.GetVariableDateOfMonth(
+				date, nthWeekday, dayOfWeek);
+			Assert.IsNotNull(result);
+			Assert.AreEqual(expected, result);
 
+		}
+		[TestMethod]
+		[DynamicData(nameof(GetNextMonthWithValidVariableDateData), DynamicDataSourceType.Method)]
+		public void GetNextMonthWithValidVariableDate
+		(
+			DateTimeOffset date,
+			UnrepresentableDateHandling unrepresentableDateHandling,
+			int nthWeekday,
+			DayOfWeek dayOfWeek,
+			DateTimeOffset? expected
+		)
+		{
+			var result = DayOfMonthTrigger.GetNextMonthWithValidVariableDate(
+				date, unrepresentableDateHandling, nthWeekday, dayOfWeek);
+			Assert.IsNotNull(result);
+			Assert.AreEqual(expected, result);
+
+		}
 		public static IEnumerable<object[]> GetNextExecutionData()
 		{
 			// Execution later same day.
@@ -223,6 +270,271 @@ namespace MFiles.VAF.Extensions.Tests.ScheduledExecution
 				UnrepresentableDateHandling.LastDayOfMonth,
 				new DateTimeOffset?[] { new DateTimeOffset(2024, 02, 29, 0, 0, 0, 0, TimeSpan.Zero) }
 			};
+			// Variable Day: -1st Saturday of March -> Invalid
+			//yield return new object[]
+			//{
+			//	new DateTimeOffset(2025, )
+			//}
+		}
+		public static IEnumerable<object[]> GetVariableDateOfMonthData()
+		{
+			// -1st Wednesday (Invalid) -> -1
+			yield return new object[]
+			{
+				new DateTimeOffset(2025, 2, 23, 1, 2, 3, TimeSpan.Zero),
+				-1,
+				DayOfWeek.Wednesday,
+				-1
+			};
+			// 6th Thursday (Invalid) -> -1
+			yield return new object[]
+			{
+				new DateTimeOffset(2025, 2, 23, 1, 2, 3, TimeSpan.Zero),
+				6,
+				DayOfWeek.Thursday,
+				-1
+			};
+			// 1st Friday of Jan 2025 -> 3
+			yield return new object[]
+			{
+				new DateTimeOffset(2025, 1, 23, 1, 2, 3, TimeSpan.Zero),
+				1,
+				DayOfWeek.Friday,
+				3
+			};
+			// 1st Wednesday of Jan 2025 (1st of the month) -> 1
+			yield return new object[]
+			{
+				new DateTimeOffset(2025, 1, 23, 1, 2, 3, TimeSpan.Zero),
+				1,
+				DayOfWeek.Wednesday,
+				1
+			};
+			// 2nd Thursday of Jan 2025 -> 9
+			yield return new object[]
+			{
+				new DateTimeOffset(2025, 1, 3, 1, 2, 3, TimeSpan.Zero),
+				2,
+				DayOfWeek.Thursday,
+				9
+			};
+			// 2nd Wednesday of Jan 2025 -> 8
+			yield return new object[]
+			{
+				new DateTimeOffset(2025, 1, 13, 1, 2, 3, TimeSpan.Zero),
+				2,
+				DayOfWeek.Wednesday,
+				8
+			};
+			// 1st Tuesday of Jan 2025 -> 7
+			yield return new object[]
+			{
+				new DateTimeOffset(2025, 1, 13, 1, 2, 3, TimeSpan.Zero),
+				1,
+				DayOfWeek.Tuesday,
+				7
+			};
+			// 4th Monday of Jan 2025 -> 27
+			yield return new object[]
+			{
+				new DateTimeOffset(2025, 1, 13, 1, 2, 3, TimeSpan.Zero),
+				4,
+				DayOfWeek.Monday,
+				27
+			};
+			// 5th Wednesday of Jan 2025 -> 27
+			yield return new object[]
+			{
+				new DateTimeOffset(2025, 1, 13, 1, 2, 3, TimeSpan.Zero),
+				5,
+				DayOfWeek.Wednesday,
+				29
+			};
+			// 5th Friday of Jan 2025 (Last day of month) -> 31
+			yield return new object[]
+			{
+				new DateTimeOffset(2025, 1, 13, 1, 2, 3, TimeSpan.Zero),
+				5,
+				DayOfWeek.Friday,
+				31
+			};
+			// 5th Saturday of Jan 2025 (Does not exist) -> -1
+			yield return new object[]
+			{
+				new DateTimeOffset(2025, 1, 13, 1, 2, 3, TimeSpan.Zero),
+				5,
+				DayOfWeek.Saturday, 
+				-1
+			};
+			// 5th Monday of Jan 2025 (Does not exist) -> -1
+			yield return new object[]
+			{
+				new DateTimeOffset(2025, 1, 13, 1, 2, 3, TimeSpan.Zero),
+				5,
+				DayOfWeek.Monday, 
+				-1
+			};
+			// Feb Testing: 4th Friday of Feb 2025 -> 28
+			yield return new object[]
+			{
+				new DateTimeOffset(2025, 2, 13, 1, 2, 3, TimeSpan.Zero),
+				4,
+				DayOfWeek.Friday, 
+				28
+			};
+			// Feb Testing: 4th Saturday of Feb 2025 -> 22
+			yield return new object[]
+			{
+				new DateTimeOffset(2025, 2, 13, 1, 2, 3, TimeSpan.Zero),
+				4,
+				DayOfWeek.Saturday,
+				22
+			};
+			// Feb Testing: 5th Saturday of Feb 2025 (Does not exist) -> -1 
+			yield return new object[]
+			{
+				new DateTimeOffset(2025, 2, 13, 1, 2, 3, TimeSpan.Zero),
+				5,
+				DayOfWeek.Saturday,
+				-1
+			};
+			// Feb Testing LEAP YEAR: 4th Monday of Feb 2028-> 28
+			yield return new object[]
+			{
+				new DateTimeOffset(2028, 2, 13, 1, 2, 3, TimeSpan.Zero),
+				4,
+				DayOfWeek.Monday,
+				28
+			};
+			// Feb Testing LEAP YEAR: 5th Tuesday of Feb 2028-> 29
+			yield return new object[]
+			{
+				new DateTimeOffset(2028, 2, 13, 1, 2, 3, TimeSpan.Zero),
+				5,
+				DayOfWeek.Tuesday,
+				29
+			};
+			// End of year: 5th Wed of Dec 2025 -> 31
+			yield return new object[]
+			{
+				new DateTimeOffset(2025, 12, 13, 1, 2, 3, TimeSpan.Zero),
+				5,
+				DayOfWeek.Wednesday,
+				31
+			};
+			// End of year: 5th Thursday of Dec 2025 (DNE) -> -1
+			yield return new object[]
+			{
+				new DateTimeOffset(2025, 12, 13, 1, 2, 3, TimeSpan.Zero),
+				5,
+				DayOfWeek.Thursday,
+				-1
+			};
+
+		}
+		public static IEnumerable<object[]> GetNextMonthWithValidVariableDateData()
+		{
+			// Unrepresentable = SKIP - Jan 2025 - 1st Saturday -> 1 Feb 2025 
+			yield return new object[]
+			{
+				new DateTimeOffset(2025, 1, 1, 1, 2, 3, TimeSpan.Zero),
+				UnrepresentableDateHandling.Skip,
+				1,
+				DayOfWeek.Saturday,
+				new DateTimeOffset(2025, 2, 1, 0, 0, 0, TimeSpan.Zero)
+			};
+			// Unrepresentable = SKIP - Jan 2025 - 1st Sunday -> 2 Feb 2025
+			yield return new object[]
+			{
+				new DateTimeOffset(2025, 1, 1, 1, 2, 3, TimeSpan.Zero),
+				UnrepresentableDateHandling.Skip,
+				1,
+				DayOfWeek.Sunday,
+				new DateTimeOffset(2025, 2, 2, 0, 0, 0, TimeSpan.Zero)
+			};
+			// Unrepresentable = SKIP - Jan 2025 - 2ND Sunday -> 9 Feb 2025
+			yield return new object[]
+			{
+				new DateTimeOffset(2025, 1, 1, 1, 2, 3, TimeSpan.Zero),
+				UnrepresentableDateHandling.Skip,
+				2,
+				DayOfWeek.Sunday,
+				new DateTimeOffset(2025, 2, 9, 0, 0, 0, TimeSpan.Zero)
+			};
+			// Unrepresentable = SKIP - Jan 2025 - 3ND Sunday -> 16 Feb 2025
+			yield return new object[]
+			{
+				new DateTimeOffset(2025, 1, 1, 1, 2, 3, TimeSpan.Zero),
+				UnrepresentableDateHandling.Skip,
+				3,
+				DayOfWeek.Sunday,
+				new DateTimeOffset(2025, 2, 16, 0, 0, 0, TimeSpan.Zero)
+			};
+			// Unrepresentable = SKIP - Jan 2025 - 4TH Sunday -> 23 Feb 2025
+			yield return new object[]
+			{
+				new DateTimeOffset(2025, 1, 1, 1, 2, 3, TimeSpan.Zero),
+				UnrepresentableDateHandling.Skip,
+				4,
+				DayOfWeek.Sunday,
+				new DateTimeOffset(2025, 2, 23, 0, 0, 0, TimeSpan.Zero)
+			};
+			// Unrepresentable = SKIP - Jan 2025 - 4TH Friday -> 28 Feb 2025
+			yield return new object[]
+			{
+				new DateTimeOffset(2025, 1, 1, 1, 2, 3, TimeSpan.Zero),
+				UnrepresentableDateHandling.Skip,
+				4,
+				DayOfWeek.Friday,
+				new DateTimeOffset(2025, 2, 28, 0, 0, 0, TimeSpan.Zero)
+			};
+			// Unrepresentable = SKIP - Jan 2025 - 5TH Saturday (Invalid, Skip Feb) -> 29 March 2025
+			yield return new object[]
+			{
+				new DateTimeOffset(2025, 1, 1, 1, 2, 3, TimeSpan.Zero),
+				UnrepresentableDateHandling.Skip,
+				5,
+				DayOfWeek.Saturday,
+				new DateTimeOffset(2025, 3, 29, 0, 0, 0, TimeSpan.Zero)
+			};
+			// Unrepresentable = SKIP - Jan 2025 - 5TH Wednesday (Invalid, Skip Feb AND Skip Mar) -> 30 April 2025
+			yield return new object[]
+			{
+				new DateTimeOffset(2025, 1, 1, 1, 2, 3, TimeSpan.Zero),
+				UnrepresentableDateHandling.Skip,
+				5,
+				DayOfWeek.Wednesday,
+				new DateTimeOffset(2025, 4, 30, 0, 0, 0, TimeSpan.Zero)
+			};
+			// Unrepresentable = EndOfMonth - Jan 2025 - 5TH Saturday (Invalid, use end of month) -> 28 Feb 2025
+			yield return new object[]
+			{
+				new DateTimeOffset(2025, 1, 1, 1, 2, 3, TimeSpan.Zero),
+				UnrepresentableDateHandling.LastDayOfMonth,
+				5,
+				DayOfWeek.Saturday,
+				new DateTimeOffset(2025, 2, 28, 0, 0, 0, TimeSpan.Zero)
+			};
+			// LEAP YEAR - Unrepresentable = SKIP - Jan 2028 - 5th Tuesday -> 29 Feb 2028
+			yield return new object[]
+			{
+				new DateTimeOffset(2028, 1, 1, 1, 2, 3, TimeSpan.Zero),
+				UnrepresentableDateHandling.Skip,
+				5,
+				DayOfWeek.Tuesday,
+				new DateTimeOffset(2028, 2, 29, 0, 0, 0, TimeSpan.Zero)
+			};
+			// LEAP YEAR - Unrepresentable = SKIP - Jan 2028 - 5th Wednesday (DNE)-> 29 Mar 2028
+			yield return new object[]
+			{
+				new DateTimeOffset(2028, 1, 1, 1, 2, 3, TimeSpan.Zero),
+				UnrepresentableDateHandling.Skip,
+				5,
+				DayOfWeek.Wednesday,
+				new DateTimeOffset(2028, 3, 29, 0, 0, 0, TimeSpan.Zero)
+			};
+
+
 		}
 	}
 }

--- a/MFiles.VAF.Extensions/Configuration/ScheduledExecution/DayOfMonthTrigger.cs
+++ b/MFiles.VAF.Extensions/Configuration/ScheduledExecution/DayOfMonthTrigger.cs
@@ -176,7 +176,12 @@ namespace MFiles.VAF.Extensions.ScheduledExecution
 				// get the desired date for THIS month.
 				int thisMonth_Date = GetVariableDateOfMonth(after, nthWeekday, dayOfWeek);
 				// get the desired date for NEXT runtime (next month or otherwise, depending on UnrepresentableDateHandling).
-				DateTimeOffset nextRuntime_Date = GetNextMonthWithValidVariableDate(after, unrepresentableDateHandling, nthWeekday, dayOfWeek);
+				DateTimeOffset? nextRuntime_Date = GetNextMonthWithValidVariableDate(after, unrepresentableDateHandling, nthWeekday, dayOfWeek);
+				if (!nextRuntime_Date.HasValue)
+				{
+					// return no values.
+					yield break;
+				}
 				// If thisMonth_Date == -1, determine how to handle via UnrepresentableDateHandling
 				if (thisMonth_Date == -1)
 				{
@@ -189,20 +194,20 @@ namespace MFiles.VAF.Extensions.ScheduledExecution
 						// If this is TODAY, return the next run also.
 						if (thisMonth_RunDate.Day == after.Day)
 						{
-							yield return nextRuntime_Date;
+							yield return nextRuntime_Date.Value;
 						}
 					}
 					else
 					{
 						// Skip this month entirely. Return next runtime.
-						yield return nextRuntime_Date;
+						yield return nextRuntime_Date.Value;
 					}
 				}
 				// if thisMonth_Date = today, then return it AND return the next run next month.
 				else if (thisMonth_Date == after.Day)
 				{
 					yield return after;
-					yield return nextRuntime_Date;
+					yield return nextRuntime_Date.Value;
 
 				}
 				// if thisMonth_Date is later this month, return it.
@@ -213,7 +218,7 @@ namespace MFiles.VAF.Extensions.ScheduledExecution
 				else
 				{
 					// Return only next month's run.
-					yield return nextRuntime_Date;
+					yield return nextRuntime_Date.Value;
 				}
 			}
 			else {
@@ -326,11 +331,14 @@ namespace MFiles.VAF.Extensions.ScheduledExecution
 		/// <param name="nthWeekday"></param>
 		/// <param name="dayOfWeek"></param>
 		/// <returns></returns>
-		internal static DateTimeOffset GetNextMonthWithValidVariableDate(DateTimeOffset after, UnrepresentableDateHandling unrepresentableDateHandling, int nthWeekday, DayOfWeek dayOfWeek)
+		internal static DateTimeOffset? GetNextMonthWithValidVariableDate(DateTimeOffset after, UnrepresentableDateHandling unrepresentableDateHandling, int nthWeekday, DayOfWeek dayOfWeek)
 		{
 			DateTimeOffset? returnValue = null;
 			// Get next runtime.
-			
+			if(nthWeekday < 1 || nthWeekday > 5)
+			{
+				return null;
+			}
 			var sanity = 0;
 			// Guarenteed to find a 1-5th weekday within a year. 
 			while (sanity++ < 13)

--- a/MFiles.VAF.Extensions/Configuration/ScheduledExecution/DayOfMonthTrigger.cs
+++ b/MFiles.VAF.Extensions/Configuration/ScheduledExecution/DayOfMonthTrigger.cs
@@ -1,4 +1,5 @@
 ﻿using MFiles.VAF.Configuration;
+using MFiles.VAF.Extensions.Configuration.ScheduledExecution;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -40,20 +41,62 @@ namespace MFiles.VAF.Extensions.ScheduledExecution
 		)]
 		public UnrepresentableDateHandling UnrepresentableDateHandling { get; set; }
 			= UnrepresentableDateHandling.Skip;
+		/// <summary>
+		/// Triggered on a specific date of the month, or the nth weekday of the month?
+		/// If set to SpecificDate, show TriggerDays config.
+		/// If set to VariableDate, show 
+		/// </summary>
+		[DataMember]
+		[JsonConfEditor
+		(
+			Label = ResourceMarker.Id + nameof(Resources.Configuration.Schedule_MonthlyTrigger_DayType_Label),
+			HelpText = ResourceMarker.Id + nameof(Resources.Configuration.Schedule_MonthlyTrigger_DayType_HelpText)
+		)]
+		public DayOfMonthTriggerType DayType { get; set; }
 
 		/// <summary>
 		/// The days of the month to trigger the schedule.
 		/// Days outside of a valid range (e.g. 30th February, or 99th October) are handled
 		/// as per <see cref="UnrepresentableDateHandling"/>.
+		/// Only shown when DayType = SpecificDate.
 		/// </summary>
 		[DataMember]
 		[JsonConfEditor
 		(
 			Label = ResourceMarker.Id + nameof(Resources.Configuration.Schedule_DayOfMonthTrigger_TriggerDays_Label),
 			HelpText = ResourceMarker.Id + nameof(Resources.Configuration.Schedule_DayOfMonthTrigger_TriggerDays_HelpText),
-			ChildName = ResourceMarker.Id + nameof(Resources.Configuration.Schedule_DayOfMonthTrigger_TriggerDays_ChildName)
+			ChildName = ResourceMarker.Id + nameof(Resources.Configuration.Schedule_DayOfMonthTrigger_TriggerDays_ChildName),
+			ShowWhen = ".parent._children{.key == 'DayType' && .value == 'SpecificDate' }"
 		)]
 		public List<int> TriggerDays { get; set; } = new List<int>();
+
+		/// <summary>
+		/// The Nth Weekday on which to trigger the schedule.
+		/// Days outside of valid range (e.g. 7th Saturday of the Month) are handled
+		/// as per <see cref="UnrepresentableDateHandling"/>.
+		/// Only shown when DayType = VariableDate.
+		/// </summary>
+		[DataMember]
+		[JsonConfEditor(
+			Label = ResourceMarker.Id + nameof(Resources.Configuration.Schedule_DayOfMonthTrigger_NthDay_Label),
+			HelpText = ResourceMarker.Id + nameof(Resources.Configuration.Schedule_DayOfMonthTrigger_NthDay_HelpText),
+			ShowWhen = ".parent._children{.key == 'DayType' && .value == 'VariableDate' }"
+		)]
+		public int nthDay { get; set; }
+
+		/// <summary>
+		/// The weekday on which to trigger the schedule.
+		/// Days outside of valid range (e.g. 7th Saturday of the Month) are handled
+		/// as per <see cref="UnrepresentableDateHandling"/>.
+		/// Only shown when DayType = VariableDate.
+		/// </summary>
+		[DataMember]
+		[JsonConfEditor(
+			Label = ResourceMarker.Id + nameof(Resources.Configuration.Schedule_DayOfMonthTrigger_Weekday_Label),
+			ShowWhen = ".parent._children{.key == 'DayType' && .value == 'VariableDate' }"
+		)]
+		public DayOfWeek weekday { get; set; }
+
 
 		/// <summary>
 		/// Creates a <see cref="DayOfMonthTrigger"/> instance.
@@ -87,7 +130,7 @@ namespace MFiles.VAF.Extensions.ScheduledExecution
 			return this.TriggerDays
 				.SelectMany
 				(
-					d => GetNextDayOfMonth(after.Value, d, this.UnrepresentableDateHandling)
+					d => GetNextDayOfMonth(after.Value, d, this.UnrepresentableDateHandling, this.DayType, this.nthDay, this.weekday)
 				)
 				.Select
 				(
@@ -114,76 +157,219 @@ namespace MFiles.VAF.Extensions.ScheduledExecution
 		/// </returns>
 		internal static IEnumerable<DateTimeOffset> GetNextDayOfMonth
 		(
-			DateTimeOffset after, 
+			DateTimeOffset after,
 			int dayOfMonth,
-			UnrepresentableDateHandling unrepresentableDateHandling
+			UnrepresentableDateHandling unrepresentableDateHandling,
+			DayOfMonthTriggerType triggerType = DayOfMonthTriggerType.SpecificDate,
+			int nthWeekday = -1,
+			DayOfWeek dayOfWeek = DayOfWeek.Sunday
 		)
 		{
-			// If the day of the month is invalid then return no values.
-			if (dayOfMonth < 1 || dayOfMonth > 32)
-				yield break;
-
-			// Switch logic depending on the current day.
-			if (dayOfMonth == after.Day)
+			// If variable date, determine the dayOfMonth.
+			if (triggerType == DayOfMonthTriggerType.VariableDate)
 			{
-				// It's today.
-				// We could be running today or the same day next month (depending on trigger times).
-				// Return both options.
-				yield return after;
-
-				yield return
-					new DateTimeOffset(after.Year, after.Month, 1, 0, 0, 0, after.Offset)
-						.AddMonths(1) // One month
-						.AddDays(dayOfMonth - 1); // Move forward to the correct day.
-			}
-			else if (dayOfMonth < after.Day)
-			{
-				// This day has already passed.
-				// Return the correct day next month.
-				yield return new DateTimeOffset(after.Year, after.Month, dayOfMonth, 0, 0, 0, after.Offset)
-					.AddMonths(1);
-			}
-			else
-			{
-				// Day is in the future this month.
-				var sanity = 0;
-				var month = after.Month;
-				while (sanity++ < 6)
+				// If the nthWeekday is invalid, return no values.
+				if (nthWeekday < 1 || nthWeekday > 5)
 				{
-					DateTimeOffset? date = null;
-					try
+					yield break;
+				}
+				// get the desired date for THIS month.
+				int thisMonth_Date = GetVariableDateOfMonth(after, nthWeekday, dayOfWeek);
+				// get the desired date for NEXT runtime (next month or otherwise, depending on UnrepresentableDateHandling).
+				DateTimeOffset nextRuntime_Date = GetNextMonthWithValidVariableDate(after, unrepresentableDateHandling, nthWeekday, dayOfWeek);
+				// If thisMonth_Date == -1, determine how to handle via UnrepresentableDateHandling
+				if (thisMonth_Date == -1)
+				{
+					if (unrepresentableDateHandling == UnrepresentableDateHandling.LastDayOfMonth)
 					{
-						// Can we represent this date?
-						// If not then we've asked for 30th Feb or similar.
-						date = new DateTimeOffset(after.Year, month, dayOfMonth, 0, 0, 0, 0, after.Offset);
-					}
-					catch
-					{
-						// What should we do?
-						switch (unrepresentableDateHandling)
-						{
-							case UnrepresentableDateHandling.LastDayOfMonth:
-								// Get the last day of this month instead.
-								date = new DateTimeOffset(after.Year, month, 1, 0, 0, 0, after.Offset)
+						DateTimeOffset thisMonth_RunDate = new DateTimeOffset(after.Year, after.Month, 1, 0, 0, 0, after.Offset)
 									.AddMonths(1)
 									.AddDays(-1);
-								break;
-							default:
-								// Allow it to try the next month.
-								date = null;
-								month++;
-								break;
+						yield return thisMonth_RunDate;
+						// If this is TODAY, return the next run also.
+						if (thisMonth_RunDate.Day == after.Day)
+						{
+							yield return nextRuntime_Date;
 						}
 					}
-
-					// If we can represent it then return it, otherwise move to next month.
-					if (date.HasValue)
+					else
 					{
-						yield return date.Value;
-						break;
+						// Skip this month entirely. Return next runtime.
+						yield return nextRuntime_Date;
+					}
+				}
+				// if thisMonth_Date = today, then return it AND return the next run next month.
+				else if (thisMonth_Date == after.Day)
+				{
+					yield return after;
+					yield return nextRuntime_Date;
+
+				}
+				// if thisMonth_Date is later this month, return it.
+				else if (thisMonth_Date > after.Day)
+				{
+					yield return new DateTimeOffset(after.Year, after.Month, thisMonth_Date, 0, 0, 0, after.Offset);
+				}
+				else
+				{
+					// Return only next month's run.
+					yield return nextRuntime_Date;
+				}
+			}
+			else {
+				// If the day of the month is invalid then return no values.
+				if (dayOfMonth < 1 || dayOfMonth > 32)
+					yield break;
+
+				// Switch logic depending on the current day.
+				if (dayOfMonth == after.Day)
+				{
+					// It's today.
+					// We could be running today or the same day next month (depending on trigger times).
+					// Return both options.
+					yield return after;
+
+					yield return
+						new DateTimeOffset(after.Year, after.Month, 1, 0, 0, 0, after.Offset)
+							.AddMonths(1) // One month
+							.AddDays(dayOfMonth - 1); // Move forward to the correct day.
+				}
+				else if (dayOfMonth < after.Day)
+				{
+					// This day has already passed.
+					// Return the correct day next month.
+					yield return new DateTimeOffset(after.Year, after.Month, dayOfMonth, 0, 0, 0, after.Offset)
+						.AddMonths(1);
+				}
+				else
+				{
+					// Day is in the future this month.
+					var sanity = 0;
+					var month = after.Month;
+					while (sanity++ < 6)
+					{
+						DateTimeOffset? date = null;
+						try
+						{
+							// Can we represent this date?
+							// If not then we've asked for 30th Feb or similar.
+							date = new DateTimeOffset(after.Year, month, dayOfMonth, 0, 0, 0, 0, after.Offset);
+						}
+						catch
+						{
+							// What should we do?
+							switch (unrepresentableDateHandling)
+							{
+								case UnrepresentableDateHandling.LastDayOfMonth:
+									// Get the last day of this month instead.
+									date = new DateTimeOffset(after.Year, month, 1, 0, 0, 0, after.Offset)
+										.AddMonths(1)
+										.AddDays(-1);
+									break;
+								default:
+									// Allow it to try the next month.
+									date = null;
+									month++;
+									break;
+							}
+						}
+
+						// If we can represent it then return it, otherwise move to next month.
+						if (date.HasValue)
+						{
+							yield return date.Value;
+							break;
+						}
 					}
 				}
 			}
+
+		}
+		/// <summary>
+		/// Gets the Nth Weekday of the month specified by the date.
+		/// If its determined that the Nth weekday of the specified month does not exist, returns -1.
+		/// </summary>
+		/// <param name="date"></param>
+		/// <param name="nthWeekday"></param>
+		/// <param name="dayOfWeek"></param>
+		/// <returns></returns>
+		internal static int GetVariableDateOfMonth
+		(
+			DateTimeOffset date,
+			int nthWeekday,
+			DayOfWeek dayOfWeek
+		)
+		{
+			DateTimeOffset curDateTimeOS = new DateTimeOffset(date.Year, date.Month, 1, 0, 0, 0, date.Offset);
+			// Get the first dayOfWeek of the month.
+			while(curDateTimeOS.DayOfWeek != dayOfWeek)
+			{
+				curDateTimeOS = curDateTimeOS.AddDays(1);
+			}
+			// Add (nthWeekday - 1) * 7 days.
+			curDateTimeOS = curDateTimeOS.AddDays((nthWeekday - 1) * 7);
+			// Is this date outside of the specific month? (e.g. the 5th Saturday of November does not exist)/
+			if(date.Month != curDateTimeOS.Month)
+			{
+				return -1;
+			}
+			else
+			{
+				return curDateTimeOS.Day; 
+			}
+		}
+		/// <summary>
+		/// Helper to find the next valid runtime beyond current after.Month.
+		/// </summary>
+		/// <param name="after"></param>
+		/// <param name="unrepresentableDateHandling"></param>
+		/// <param name="nthWeekday"></param>
+		/// <param name="dayOfWeek"></param>
+		/// <returns></returns>
+		internal static DateTimeOffset GetNextMonthWithValidVariableDate(DateTimeOffset after, UnrepresentableDateHandling unrepresentableDateHandling, int nthWeekday, DayOfWeek dayOfWeek)
+		{
+			DateTimeOffset? returnValue = null;
+			// Get next runtime.
+			
+			var sanity = 0;
+			// Guarenteed to find a 1-5th weekday within a year. 
+			while (sanity++ < 13)
+			{
+				DateTimeOffset? date = after.AddMonths(sanity);
+				// Attempt to get the next month's run date.
+				int runDate = GetVariableDateOfMonth(date.Value, nthWeekday, dayOfWeek);
+				if (runDate == -1)
+				{
+					if (unrepresentableDateHandling == UnrepresentableDateHandling.LastDayOfMonth)
+					{
+						// Returns the next month's last 
+						returnValue = new DateTimeOffset(date.Value.Year, date.Value.Month, 1, 0, 0, 0, after.Offset)
+										.AddMonths(1)
+										.AddDays(-1);
+						break;
+					}
+					else
+					{
+						// Try the next month.
+						date = null;
+					}
+					
+				}
+				else
+				{
+					// Valid date.
+					date = new DateTimeOffset(date.Value.Year, date.Value.Month, 1, 0, 0, 0, date.Value.Offset)
+											.AddDays(runDate - 1);
+				}
+				// If we can represent it then return it, otherwise move to next month.
+				if (date.HasValue)
+				{
+					returnValue =  date.Value;
+					break;
+				}
+				}
+			// Will always return a value.
+			return returnValue.Value;
 		}
 
 		/// <inheritdoc />

--- a/MFiles.VAF.Extensions/Configuration/ScheduledExecution/DayOfMonthTriggerType.cs
+++ b/MFiles.VAF.Extensions/Configuration/ScheduledExecution/DayOfMonthTriggerType.cs
@@ -1,0 +1,18 @@
+﻿using MFiles.VAF.Configuration;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace MFiles.VAF.Extensions.Configuration.ScheduledExecution
+{
+	[UsesConfigurationResources]
+	public enum DayOfMonthTriggerType
+	{
+		[JsonConfEditor(Label = ResourceMarker.Id + nameof(Resources.Configuration.Schedule_MonthlyTrigger_DayType_SpecificDate))]
+		SpecificDate = 0,
+		[JsonConfEditor(Label = ResourceMarker.Id + nameof(Resources.Configuration.Schedule_MonthlyTrigger_DayType_VariableDate))]
+		VariableDate = 1
+	}
+}

--- a/MFiles.VAF.Extensions/Resources/Configuration.Designer.cs
+++ b/MFiles.VAF.Extensions/Resources/Configuration.Designer.cs
@@ -187,6 +187,24 @@ namespace MFiles.VAF.Extensions.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Ordinal number for the occurrence of a certain weekday within a month to schedule. For instance, set to &quot;1&quot; for the first Saturday of the month..
+        /// </summary>
+        internal static string Schedule_DayOfMonthTrigger_NthDay_HelpText {
+            get {
+                return ResourceManager.GetString("Schedule_DayOfMonthTrigger_NthDay_HelpText", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Nth Weekday.
+        /// </summary>
+        internal static string Schedule_DayOfMonthTrigger_NthDay_Label {
+            get {
+                return ResourceManager.GetString("Schedule_DayOfMonthTrigger_NthDay_Label", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Day.
         /// </summary>
         internal static string Schedule_DayOfMonthTrigger_TriggerDays_ChildName {
@@ -228,6 +246,51 @@ namespace MFiles.VAF.Extensions.Resources {
         internal static string Schedule_DayOfMonthTrigger_UnrepresentableDateHandling_Label {
             get {
                 return ResourceManager.GetString("Schedule_DayOfMonthTrigger_UnrepresentableDateHandling_Label", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Weekday.
+        /// </summary>
+        internal static string Schedule_DayOfMonthTrigger_Weekday_Label {
+            get {
+                return ResourceManager.GetString("Schedule_DayOfMonthTrigger_Weekday_Label", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Use &quot;Specific Date&quot; if you require a specific date every month (e.g. 5th of every month). Use &quot;Variable Date&quot; if you require the nth weekday of every month (e.g. the second Tuesday of every month)..
+        /// </summary>
+        internal static string Schedule_MonthlyTrigger_DayType_HelpText {
+            get {
+                return ResourceManager.GetString("Schedule_MonthlyTrigger_DayType_HelpText", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Date Type.
+        /// </summary>
+        internal static string Schedule_MonthlyTrigger_DayType_Label {
+            get {
+                return ResourceManager.GetString("Schedule_MonthlyTrigger_DayType_Label", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Specific Date.
+        /// </summary>
+        internal static string Schedule_MonthlyTrigger_DayType_SpecificDate {
+            get {
+                return ResourceManager.GetString("Schedule_MonthlyTrigger_DayType_SpecificDate", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Variable Date.
+        /// </summary>
+        internal static string Schedule_MonthlyTrigger_DayType_VariableDate {
+            get {
+                return ResourceManager.GetString("Schedule_MonthlyTrigger_DayType_VariableDate", resourceCulture);
             }
         }
         

--- a/MFiles.VAF.Extensions/Resources/Configuration.resx
+++ b/MFiles.VAF.Extensions/Resources/Configuration.resx
@@ -171,6 +171,12 @@
   <data name="Schedule_DailyTrigger_TriggerTimes_Label" xml:space="preserve">
     <value>Trigger Times</value>
   </data>
+  <data name="Schedule_DayOfMonthTrigger_NthDay_HelpText" xml:space="preserve">
+    <value>Ordinal number for the occurrence of a certain weekday within a month to schedule. For instance, set to "1" for the first Saturday of the month.</value>
+  </data>
+  <data name="Schedule_DayOfMonthTrigger_NthDay_Label" xml:space="preserve">
+    <value>Nth Weekday</value>
+  </data>
   <data name="Schedule_DayOfMonthTrigger_TriggerDays_ChildName" xml:space="preserve">
     <value>Day</value>
   </data>
@@ -185,6 +191,21 @@
   </data>
   <data name="Schedule_DayOfMonthTrigger_UnrepresentableDateHandling_Label" xml:space="preserve">
     <value>Unrepresentable Date Handling</value>
+  </data>
+  <data name="Schedule_DayOfMonthTrigger_Weekday_Label" xml:space="preserve">
+    <value>Weekday</value>
+  </data>
+  <data name="Schedule_MonthlyTrigger_DayType_HelpText" xml:space="preserve">
+    <value>Use "Specific Date" if you require a specific date every month (e.g. 5th of every month). Use "Variable Date" if you require the nth weekday of every month (e.g. the second Tuesday of every month).</value>
+  </data>
+  <data name="Schedule_MonthlyTrigger_DayType_Label" xml:space="preserve">
+    <value>Date Type</value>
+  </data>
+  <data name="Schedule_MonthlyTrigger_DayType_SpecificDate" xml:space="preserve">
+    <value>Specific Date</value>
+  </data>
+  <data name="Schedule_MonthlyTrigger_DayType_VariableDate" xml:space="preserve">
+    <value>Variable Date</value>
   </data>
   <data name="Schedule_Triggers_HelpText" xml:space="preserve">
     <value />

--- a/MFiles.VAF.Extensions/Resources/Schedule.Designer.cs
+++ b/MFiles.VAF.Extensions/Resources/Schedule.Designer.cs
@@ -108,9 +108,18 @@ namespace MFiles.VAF.Extensions.Resources {
         /// <summary>
         ///   Looks up a localized string similar to On the {0} of the month at the following times: {1}..
         /// </summary>
-        internal static string Triggers_DayOfMonthTrigger {
+        internal static string Triggers_DayOfMonthTrigger_SpecificDate {
             get {
-                return ResourceManager.GetString("Triggers_DayOfMonthTrigger", resourceCulture);
+                return ResourceManager.GetString("Triggers_DayOfMonthTrigger_SpecificDate", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Every {0} {1} of the month at the following times: {2}..
+        /// </summary>
+        internal static string Triggers_DayOfMonthTrigger_VariableDate {
+            get {
+                return ResourceManager.GetString("Triggers_DayOfMonthTrigger_VariableDate", resourceCulture);
             }
         }
         

--- a/MFiles.VAF.Extensions/Resources/Schedule.fi.resx
+++ b/MFiles.VAF.Extensions/Resources/Schedule.fi.resx
@@ -133,7 +133,7 @@
     <value>Päivittäin seuraavina kellonaikoina: {0}.</value>
     <comment>Shown to describe a daily trigger for a schedule.  {0} will be replaced with the trigger times.</comment>
   </data>
-  <data name="Triggers_DayOfMonthTrigger" xml:space="preserve">
+  <data name="Triggers_DayOfMonthTrigger_SpecificDate" xml:space="preserve">
     <value>Kuukauden {0} päivä seuraavina kellonaikoina: {1}.</value>
     <comment>Shown to describe a day-of-month trigger. {0} will be replaced with the days of the month this will trigger, and {1} will be replaced with the trigger times.</comment>
   </data>

--- a/MFiles.VAF.Extensions/Resources/Schedule.fr.resx
+++ b/MFiles.VAF.Extensions/Resources/Schedule.fr.resx
@@ -133,7 +133,7 @@
     <value>Quotidien aux heures : {0}.</value>
     <comment>Shown to describe a daily trigger for a schedule.  {0} will be replaced with the trigger times.</comment>
   </data>
-  <data name="Triggers_DayOfMonthTrigger" xml:space="preserve">
+  <data name="Triggers_DayOfMonthTrigger_SpecificDate" xml:space="preserve">
     <value>Le {0} du mois aux heures : {1}.</value>
     <comment>Shown to describe a day-of-month trigger. {0} will be replaced with the days of the month this will trigger, and {1} will be replaced with the trigger times.</comment>
   </data>

--- a/MFiles.VAF.Extensions/Resources/Schedule.resx
+++ b/MFiles.VAF.Extensions/Resources/Schedule.resx
@@ -133,9 +133,13 @@
     <value>Daily at the following times: {0}.</value>
     <comment>Shown to describe a daily trigger for a schedule.  {0} will be replaced with the trigger times.</comment>
   </data>
-  <data name="Triggers_DayOfMonthTrigger" xml:space="preserve">
+  <data name="Triggers_DayOfMonthTrigger_SpecificDate" xml:space="preserve">
     <value>On the {0} of the month at the following times: {1}.</value>
-    <comment>Shown to describe a day-of-month trigger. {0} will be replaced with the days of the month this will trigger, and {1} will be replaced with the trigger times.</comment>
+    <comment>Shown to describe a day-of-month trigger with Specific Date type. {0} will be replaced with the days of the month this will trigger, and {1} will be replaced with the trigger times.</comment>
+  </data>
+  <data name="Triggers_DayOfMonthTrigger_VariableDate" xml:space="preserve">
+    <value>Every {0} {1} of the month at the following times: {2}.</value>
+    <comment>Shown to describe a day-of-month trigger with Variable Date type. {0} will be replaced by an ordinal number, {1} will be replaced by the weekday, and {2} will be replaced with the trigger times.</comment>
   </data>
   <data name="Triggers_WeeklyTrigger" xml:space="preserve">
     <value>Every {0} at the following times: {1}.</value>


### PR DESCRIPTION
This pull has the following updates:
1. Updating DayOfMonthTrigger to have a new data member "Date Type" with select choices "Variable Date" or "Specific Date".
2. The "Specific Date" selection would cause this trigger configuration to behave as is currently does. User has the ability to choose Trigger Days and Trigger Times.
3. The "Variable Date" choice will hide Trigger Days configuration and instead show "Nth Weekday", a value between 1-5 inclusive, and Weekday (Mon-Sun).
4. New methods DayOfMonthTrigger.GetVariableDateOfMonth, DayOfMonthTrigger.GetNextMonthWithValidVariableDate to handle getting the current month's next run time and the next valid runtime after the current month.
5. Update existing methods for new trigger type.
6. Resource files - Added new help text, dashboard schedule string format, for new settings/trigger type (English only).
7. Updated test project to test new functionality.
I've attached a spreadsheet with all the test cases I came up with: 
[VariableDate_TestCases.xlsx](https://github.com/user-attachments/files/19438183/VariableDate_TestCases.xlsx)
