### PR TITLE
Validation changed to take place within StartOperations

### DIFF
--- a/MFiles.VAF.Extensions/ConfigurableVaultApplicationBase.ConfigurationUpdated.cs
+++ b/MFiles.VAF.Extensions/ConfigurableVaultApplicationBase.ConfigurationUpdated.cs
@@ -68,27 +68,5 @@ namespace MFiles.VAF.Extensions
 		{
 			get => base.ConfManager;
 		}
-
-		/// <inheritdoc />
-		public override void StartOperations(Vault vaultPersistent)
-		{
-			// Do we have a valid configuration?
-			this.isCurrentConfigurationValid = this.IsValid(vaultPersistent);
-
-			// Initialize the application.
-			base.StartOperations(vaultPersistent);
-
-			// Ensure that our recurring configuration is updated.
-			try
-			{
-				this.RecurringOperationConfigurationManager?.PopulateFromConfiguration(isVaultStartup: true);
-			}
-			catch(Exception e)
-			{
-				this.Logger?.Fatal(e, $"Exception mapping configuration to recurring operations.");
-			}
-
-
-		}
 	}
 }

--- a/MFiles.VAF.Extensions/ConfigurableVaultApplicationBase.cs
+++ b/MFiles.VAF.Extensions/ConfigurableVaultApplicationBase.cs
@@ -111,11 +111,22 @@ namespace MFiles.VAF.Extensions
 		protected override void StartApplication()
 		{
 			this.startApplicationCalled = true;
+			this.isCurrentConfigurationValid = this.IsValid( this.PermanentVault );
 			this.RecurringOperationConfigurationManager = new RecurringOperationConfigurationManager<TSecureConfiguration>(this);
 			this.ApplicationOverviewDashboardContentRenderer = this.GetApplicationOverviewDashboardContentRenderer();
 			this.AsynchronousDashboardContentRenderer = this.GetAsynchronousDashboardContentRenderer();
 			this.AsynchronousDashboardContentProviders.AddRange(this.GetAsynchronousDashboardContentProviders());
 			this.LoggingDashboardContentRenderer = this.GetLoggingDashboardContentRenderer();
+
+			// Ensure that our recurring configuration is updated.
+			try
+			{
+				this.RecurringOperationConfigurationManager?.PopulateFromConfiguration(isVaultStartup: true);
+			}
+			catch(Exception e)
+			{
+				this.Logger?.Fatal(e, $"Exception mapping configuration to recurring operations.");
+			}
 
 #if DEBUG
 			// In debug builds we want to show the referenced assemblies and the like.


### PR DESCRIPTION
The validation would benefit using cache-enabled M-Files API vault object. It is constructed in the StartOperations call, before calling StartApplications (which is the intended override point for app start routines). The validation is way faster if done after the cache is set up, and this improves the service start-up delay. Which is essential especially in cloud deployments.