### PR TITLE
DRAFT: Update VAF release

### DIFF
--- a/MFiles.VAF.Extensions.Tests/MFiles.VAF.Extensions.Tests.csproj
+++ b/MFiles.VAF.Extensions.Tests/MFiles.VAF.Extensions.Tests.csproj
@@ -13,12 +13,13 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="MFiles.VAF" Version="24.10.720.2" />
+    <PackageReference Include="MFiles.VAF" Version="25.3.727.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />
     <PackageReference Include="Moq" Version="4.13.1" />
     <PackageReference Include="MSTest.TestAdapter" Version="2.0.0" />
     <PackageReference Include="MSTest.TestFramework" Version="2.0.0" />
     <PackageReference Include="coverlet.collector" Version="1.0.1" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/MFiles.VAF.Extensions/MFiles.VAF.Extensions.csproj
+++ b/MFiles.VAF.Extensions/MFiles.VAF.Extensions.csproj
@@ -46,9 +46,10 @@
     </None>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="MFiles.VAF" Version="24.10.720.2" />
-    <PackageReference Include="MFiles.VAF.Configuration.Logging.NLog" Version="23.12.3" />
-    <PackageReference Include="MFilesAPI.Extensions" Version="24.4.3" />
+    <PackageReference Include="MFiles.VAF" Version="25.3.727.1" />
+    <PackageReference Include="MFiles.VAF.Configuration.Logging.NLog" Version="25.3.4" />
+    <PackageReference Include="MFilesAPI.Extensions" Version="25.2.4" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
   </ItemGroup>
   <ItemGroup>
     <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">


### PR DESCRIPTION
Updated to latest VAF release.
Updated to newest Newtonsoft release.

This will mean that projects based on the Extensions will get the latest Newtonsoft version when they update the Extensions reference.

Marked as draft as, whilst automated tests are green, I have not yet tested this in the wild.